### PR TITLE
core, react: properly type utils object in config

### DIFF
--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -12,9 +12,9 @@ import { persist, subscribeWithSelector } from 'zustand/middleware'
 import { type Mutate, type StoreApi, createStore } from 'zustand/vanilla'
 import { type Storage, createStorage, noopStorage } from './createStorage.js'
 import type { Evaluate, ExactPartial } from './types/utils.js'
-import type * as rustUtils from './utils.d.ts'
+import type * as UtilsType from './utils.d.ts'
 
-export type CreateConfigParameters = {
+export type CreateConfigParameters<U = typeof UtilsType> = {
   darkPoolAddress: Address
   priceReporterUrl: string
   relayerUrl: string
@@ -23,11 +23,13 @@ export type CreateConfigParameters = {
   rpcUrl: string
   ssr?: boolean | undefined
   storage?: Storage | null | undefined
-  utils?: typeof rustUtils
+  utils?: U
   websocketPort?: number
 }
 
-export function createConfig(parameters: CreateConfigParameters): Config {
+export function createConfig<U = typeof UtilsType>(
+  parameters: CreateConfigParameters<U>,
+): Config<U> {
   const {
     relayerUrl,
     priceReporterUrl,
@@ -150,7 +152,7 @@ export function createConfig(parameters: CreateConfigParameters): Config {
   }
 }
 
-export type Config = {
+export type Config<U = typeof UtilsType> = {
   darkPoolAddress: Address
   getPriceReporterBaseUrl: () => string
   getRelayerBaseUrl: (route?: string) => string
@@ -173,7 +175,7 @@ export type Config = {
       | undefined,
   ): () => void
   getViemClient: () => PublicClient
-  utils: typeof rustUtils
+  utils: U
   /**
    * Not part of versioned API, proceed with caution.
    * @internal

--- a/packages/react/src/hooks/useConfig.ts
+++ b/packages/react/src/hooks/useConfig.ts
@@ -6,16 +6,22 @@ import { useContext } from 'react'
 import { RenegadeContext } from '../context.js'
 import { RenegadeProviderNotFoundError } from '../errors/context.js'
 import type { ConfigParameter } from '../types/properties.js'
+import type * as UtilsType from '../../renegade-utils/index.d.ts'
 
-export type UseConfigParameters<config extends Config = Config> =
-  ConfigParameter<config>
+export type UseConfigParameters<
+  config extends Config<typeof UtilsType> = Config<typeof UtilsType>,
+> = ConfigParameter<config>
 
-export type UseConfigReturnType<config extends Config = Config> = config
+export type UseConfigReturnType<
+  config extends Config<typeof UtilsType> = Config<typeof UtilsType>,
+> = config
 
-export function useConfig<config extends Config = Config>(
-  parameters: UseConfigParameters<config> = {},
-): UseConfigReturnType<config> {
-  const config = parameters.config ?? useContext(RenegadeContext)
+export function useConfig<
+  config extends Config<typeof UtilsType> = Config<typeof UtilsType>,
+>(parameters: UseConfigParameters<config> = {}): UseConfigReturnType<config> {
+  const config =
+    parameters.config ??
+    (useContext(RenegadeContext) as Config<typeof UtilsType>)
   if (!config) throw new RenegadeProviderNotFoundError()
   return config as UseConfigReturnType<config>
 }


### PR DESCRIPTION
This PR adds generics to the createConfig function so that the utils object can be properly typed based on which environment it is in (web vs. node).