### PR TITLE
core, react: parse all numerical values as bigint for consistency

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -382,6 +382,8 @@ export const testnetTokenMapping = {
 const isDevelopment =
   process.env.VERCEL_ENV === 'development' ||
   process.env.VERCEL_ENV === 'preview' ||
+  process.env.NEXT_PUBLIC_VERCEL_ENV === 'development' ||
+  process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview' ||
   process.env.NODE_ENV === 'development'
 
 export const tokenMapping = isDevelopment

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -3,7 +3,7 @@ import type { Address } from 'viem'
 export type Task = {
   id: string
   state: TaskState
-  created_at: number
+  created_at: bigint
   task_info: TaskInfo
 }
 

--- a/packages/core/src/types/wallet.ts
+++ b/packages/core/src/types/wallet.ts
@@ -4,26 +4,11 @@ export type Exchange = 'binance' | 'coinbase' | 'kraken' | 'okx'
 
 export type NetworkOrder = {
   id: string
-  public_share_nullifier: number[]
+  public_share_nullifier: bigint[]
   local: boolean
   cluster: string
   state: string
-  validity_proofs: (ValidityProof | number[])[]
-  timestamp: number
-}
-
-type ValidityProof = {
-  statement: {
-    original_shares_nullifier?: number[]
-    reblinded_private_share_commitment?: number[]
-    merkle_root?: number[]
-    indices?: {
-      balance_send: number
-      balance_receive: number
-      order: number
-    }
-  }
-  proof: string
+  timestamp: bigint
 }
 
 export type Order = {
@@ -31,7 +16,7 @@ export type Order = {
   quote_mint: Address
   base_mint: Address
   side: 'Buy' | 'Sell'
-  type: 'Midpoint'
+  type: string
   worst_case_price: string
   amount: bigint
 }
@@ -86,6 +71,6 @@ export type OrderMetadata = {
   id: string
   state: OrderState
   filled: bigint
-  created: number
+  created: bigint
   data: Order
 }

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -45,7 +45,10 @@ export async function getRelayerRaw(url: string, headers = {}) {
       headers,
       transformResponse: (data) => {
         try {
-          return JSONBigint({ useNativeBigInt: true }).parse(data)
+          return JSONBigint({
+            useNativeBigInt: true,
+            alwaysParseAsBig: true,
+          }).parse(data)
         } catch (_error) {
           return data
         }

--- a/packages/react/src/hooks/useOrderHistory.ts
+++ b/packages/react/src/hooks/useOrderHistory.ts
@@ -54,9 +54,9 @@ export function useOrderHistory(
   if (sort) {
     sortedOrderHistory.sort((a, b) => {
       if (sort === 'asc') {
-        return a.created - b.created
+        return Number(a.created) - Number(b.created)
       }
-      return b.created - a.created
+      return Number(b.created) - Number(a.created)
     })
   }
 

--- a/packages/react/src/hooks/useTaskHistory.ts
+++ b/packages/react/src/hooks/useTaskHistory.ts
@@ -48,9 +48,9 @@ export function useTaskHistory(
   if (sort) {
     sortedTaskHistory.sort((a, b) => {
       if (sort === 'asc') {
-        return a.created_at - b.created_at
+        return Number(a.created_at) - Number(b.created_at)
       }
-      return b.created_at - a.created_at
+      return Number(b.created_at) - Number(a.created_at)
     })
   }
 


### PR DESCRIPTION
This PR changes the transform function when `GET`ting data from the API to parse all numerical values as bigint. This makes the data more consistent, as numerical values within the safe number boundaries of javascript were being processed as `number`, even if it's type was `bigint`.