### PR TITLE
wasm: common: keychain: use contracts ByteSerializable in sig gen

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.0.20
+
+### Patch Changes
+
+- wasm: implement fix for signature generation
+
 ## 0.0.19
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/core",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "VanillaJS library for Renegade",
   "files": [
     "dist/**",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/node
 
+## 0.0.20
+
+### Patch Changes
+
+- wasm: implement fix for signature generation
+- Updated dependencies
+  - @renegade-fi/core@0.0.20
+
 ## 0.0.19
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/node",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Node.js library for Renegade",
   "files": [
     "dist/**",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/react
 
+## 0.0.20
+
+### Patch Changes
+
+- wasm: implement fix for signature generation
+- Updated dependencies
+  - @renegade-fi/core@0.0.20
+
 ## 0.0.19
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/react",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "React library for Renegade",
   "files": [
     "dist/**",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/test
 
+## 0.0.20
+
+### Patch Changes
+
+- wasm: implement fix for signature generation
+- Updated dependencies
+  - @renegade-fi/core@0.0.20
+
 ## 0.0.19
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -14,6 +14,9 @@ sha2 = "0.10.8"
 uuid = { version = "1.1.2", features = ["v4", "serde"] }
 wasm-bindgen = "0.2"
 
+# === Contracts Repo Dependencies === #
+contracts-common = { git = "https://github.com/renegade-fi/renegade-contracts.git" }
+
 # === Cryptography / Arithmetic === #
 ark-bn254 = "0.4"
 ark-ed-on-bn254 = "0.4"

--- a/wasm/src/common/keychain.rs
+++ b/wasm/src/common/keychain.rs
@@ -5,6 +5,7 @@ use ethers::{
     types::{Signature, U256},
     utils::keccak256,
 };
+use contracts_common::custom_serde::BytesSerializable;
 
 use crate::types::Scalar;
 
@@ -29,7 +30,7 @@ impl Wallet {
         let key = EthersSigningKey::try_from(root_key)?;
 
         // Hash the message and sign it
-        let comm_bytes = commitment.to_biguint().to_bytes_be();
+        let comm_bytes = commitment.inner().serialize_to_bytes();
         let digest = keccak256(comm_bytes);
         let (sig, recovery_id) = key
             .sign_prehash_recoverable(&digest)


### PR DESCRIPTION
This PR updates the `sign_commitment` method on the `Wallet` struct to serialize the commitment using the `BytesSerializable` trait defined in the contracts repo. The rationale for why this is necessary is laid out in https://github.com/renegade-fi/renegade/pull/589