### PR TITLE
core: remove no persist option

### DIFF
--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -62,7 +62,7 @@ export function createConfig(parameters: CreateConfigParameters): Config {
     }
   }
 
-  let store = createStore(
+  const store = createStore(
     subscribeWithSelector(
       // only use persist middleware if storage exists
       storage
@@ -82,38 +82,6 @@ export function createConfig(parameters: CreateConfigParameters): Config {
         : getInitialState,
     ),
   )
-
-  function reinitializeStore(usePersist: boolean) {
-    const currentStorage = createStorage({
-      storage:
-        usePersist && typeof window !== 'undefined' && window.localStorage
-          ? window.localStorage
-          : noopStorage,
-    })
-    const prevState = store.getState()
-    store = createStore(
-      subscribeWithSelector(
-        usePersist && currentStorage
-          ? persist(store.getState, {
-              name: 'store',
-              partialize(state) {
-                return {
-                  id: state.id,
-                  seed: state.seed,
-                  status: state.status,
-                } satisfies PartializedState
-              },
-              skipHydration: ssr,
-              storage: currentStorage as Storage<Record<string, unknown>>,
-            })
-          : store.getState,
-      ),
-    )
-    store.setState(prevState)
-    if (!usePersist) {
-      localStorage.removeItem('renegade.store')
-    }
-  }
 
   const getRenegadeChain = (_rpcUrl?: string) => {
     const rpcUrl =
@@ -192,7 +160,6 @@ export function createConfig(parameters: CreateConfigParameters): Config {
           : undefined,
       )
     },
-    reinitializeStore,
     _internal: {
       store,
       ssr: Boolean(ssr),
@@ -210,7 +177,6 @@ export type Config = {
   pollingInterval: number
   priceReporterUrl: string
   relayerUrl: string
-  reinitializeStore: (usePersist: boolean) => void
   rpcUrl?: string
   setState: (newState: State) => void
   state: State

--- a/packages/core/src/hydrate.ts
+++ b/packages/core/src/hydrate.ts
@@ -21,7 +21,7 @@ export function hydrate(config: Config, parameters: HydrateParameters) {
     async onMount() {
       if (config._internal.ssr) {
         console.log('💧 SSR enabled, rehydrating state')
-        await config._internal.store.persist?.rehydrate()
+        await config._internal.store.persist.rehydrate()
       }
 
       if (reconnectOnMount) {

--- a/packages/core/src/utils.d.ts
+++ b/packages/core/src/utils.d.ts
@@ -1,101 +1,132 @@
 /* tslint:disable */
 /* eslint-disable */
 /**
-* @param {string} sk_root
-* @returns {any}
-*/
-export function create_wallet(sk_root: string): any;
+ * @param {string} sk_root
+ * @returns {any}
+ */
+export function create_wallet(sk_root: string): any
 /**
-* @param {string} sk_root
-* @returns {any}
-*/
-export function find_wallet(sk_root: string): any;
+ * @param {string} sk_root
+ * @returns {any}
+ */
+export function find_wallet(sk_root: string): any
 /**
-* @param {string} sk_root
-* @returns {any}
-*/
-export function derive_blinder_share(sk_root: string): any;
+ * @param {string} sk_root
+ * @returns {any}
+ */
+export function derive_blinder_share(sk_root: string): any
 /**
-* @param {string} sk_root
-* @returns {any}
-*/
-export function wallet_id(sk_root: string): any;
+ * @param {string} sk_root
+ * @returns {any}
+ */
+export function wallet_id(sk_root: string): any
 /**
-* @param {string} wallet_str
-* @param {string} from_addr
-* @param {string} mint
-* @param {string} amount
-* @param {string} permit_nonce
-* @param {string} permit_deadline
-* @param {string} permit_signature
-* @returns {any}
-*/
-export function deposit(wallet_str: string, from_addr: string, mint: string, amount: string, permit_nonce: string, permit_deadline: string, permit_signature: string): any;
+ * @param {string} wallet_str
+ * @param {string} from_addr
+ * @param {string} mint
+ * @param {string} amount
+ * @param {string} permit_nonce
+ * @param {string} permit_deadline
+ * @param {string} permit_signature
+ * @returns {any}
+ */
+export function deposit(
+  wallet_str: string,
+  from_addr: string,
+  mint: string,
+  amount: string,
+  permit_nonce: string,
+  permit_deadline: string,
+  permit_signature: string,
+): any
 /**
-* @param {string} wallet_str
-* @param {string} mint
-* @param {string} amount
-* @param {string} destination_addr
-* @returns {any}
-*/
-export function withdraw(wallet_str: string, mint: string, amount: string, destination_addr: string): any;
+ * @param {string} wallet_str
+ * @param {string} mint
+ * @param {string} amount
+ * @param {string} destination_addr
+ * @returns {any}
+ */
+export function withdraw(
+  wallet_str: string,
+  mint: string,
+  amount: string,
+  destination_addr: string,
+): any
 /**
-* @param {string} wallet_str
-* @param {string} id
-* @param {string} base_mint
-* @param {string} quote_mint
-* @param {string} side
-* @param {string} amount
-* @returns {any}
-*/
-export function new_order(wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string): any;
+ * @param {string} wallet_str
+ * @param {string} id
+ * @param {string} base_mint
+ * @param {string} quote_mint
+ * @param {string} side
+ * @param {string} amount
+ * @returns {any}
+ */
+export function new_order(
+  wallet_str: string,
+  id: string,
+  base_mint: string,
+  quote_mint: string,
+  side: string,
+  amount: string,
+): any
 /**
-* @param {string} wallet_str
-* @param {string} order_id
-* @returns {any}
-*/
-export function cancel_order(wallet_str: string, order_id: string): any;
+ * @param {string} wallet_str
+ * @param {string} order_id
+ * @returns {any}
+ */
+export function cancel_order(wallet_str: string, order_id: string): any
 /**
-* @param {string} wallet_str
-* @param {string} id
-* @param {string} base_mint
-* @param {string} quote_mint
-* @param {string} side
-* @param {string} amount
-* @returns {any}
-*/
-export function update_order(wallet_str: string, id: string, base_mint: string, quote_mint: string, side: string, amount: string): any;
+ * @param {string} wallet_str
+ * @param {string} id
+ * @param {string} base_mint
+ * @param {string} quote_mint
+ * @param {string} side
+ * @param {string} amount
+ * @returns {any}
+ */
+export function update_order(
+  wallet_str: string,
+  id: string,
+  base_mint: string,
+  quote_mint: string,
+  side: string,
+  amount: string,
+): any
 /**
-* Build authentication headers for a request
-* @param {string} sk_root
-* @param {string} req
-* @param {bigint} current_timestamp
-* @returns {any[]}
-*/
-export function build_auth_headers(sk_root: string, req: string, current_timestamp: bigint): any[];
+ * Build authentication headers for a request
+ * @param {string} sk_root
+ * @param {string} req
+ * @param {bigint} current_timestamp
+ * @returns {any[]}
+ */
+export function build_auth_headers(
+  sk_root: string,
+  req: string,
+  current_timestamp: bigint,
+): any[]
 /**
-* @param {string} seed
-* @returns {any}
-*/
-export function derive_signing_key_from_seed(seed: string): any;
+ * @param {string} seed
+ * @returns {any}
+ */
+export function derive_signing_key_from_seed(seed: string): any
 /**
-* @param {string} sk_root
-* @returns {any}
-*/
-export function get_pk_root(sk_root: string): any;
+ * @param {string} sk_root
+ * @returns {any}
+ */
+export function get_pk_root(sk_root: string): any
 /**
-* @param {string} sk_root
-* @returns {any[]}
-*/
-export function pk_root_scalars(sk_root: string): any[];
+ * @param {string} sk_root
+ * @returns {any[]}
+ */
+export function pk_root_scalars(sk_root: string): any[]
 /**
-* @param {string} sk_root
-* @param {string} message
-* @returns {any}
-*/
-export function sign_message(sk_root: string, message: string): any;
+ * @param {string} sk_root
+ * @param {string} message
+ * @returns {any}
+ */
+export function sign_message(sk_root: string, message: string): any
 /**
-* @param {string} value
-* @returns {any}
-*/
-export function bigint_to_limbs(value: string): any;
+ * @param {string} value
+ * @returns {any}
+ */
+export function bigint_to_limbs(value: string): any


### PR DESCRIPTION
This PR removes the option to reinitialize config.store, as it resulted in subscribers losing access to subscription, since a new store was being instantiated. Replaced by client side handling.