### PR TITLE
core: error if order would result in too many balances

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,8 @@
       "tsconfig.base.json",
       "wasm/**",
       "dist/**",
-      "renegade-utils/**"
+      "renegade-utils/**",
+      "*.d.ts"
     ]
   },
   "formatter": {


### PR DESCRIPTION
This PR adds a check to the `createOrder` action to panic if an order would result in too many balances. This happens if the user has a full balance array and is attempting to buy a mint that does not already exist in the balances array.