### PR TITLE
core: allow for dynamic decimal truncation

### DIFF
--- a/packages/core/src/utils/format.ts
+++ b/packages/core/src/utils/format.ts
@@ -2,13 +2,11 @@ import { formatUnits, parseUnits } from 'viem'
 
 import type { Token } from '../types/token.js'
 
-export function formatAmount(amount: bigint, token: Token) {
-  const decimals = token.decimals
-  if (!decimals) throw new Error(`Decimals not found for 0x${token.address}`)
-  let formatted = formatUnits(amount, decimals)
+export function formatAmount(amount: bigint, token: Token, decimals = 2) {
+  let formatted = formatUnits(amount, token.decimals)
   if (formatted.includes('.')) {
     const [integerPart, decimalPart = ''] = formatted.split('.')
-    formatted = `${integerPart}.${decimalPart.substring(0, 2)}`
+    formatted = `${integerPart}.${decimalPart.substring(0, decimals)}`
   }
   return formatted
 }


### PR DESCRIPTION
This PR allows for the number of decimals to truncate to to be passed as a parameter to the `formatAmount` function.