### PR TITLE
core: add function to wait for wallet indexing

### DIFF
--- a/packages/core/src/actions/createWallet.ts
+++ b/packages/core/src/actions/createWallet.ts
@@ -1,18 +1,22 @@
-import { getSkRoot } from './getSkRoot.js'
-import { waitForTaskCompletion } from './waitForTaskCompletion.js'
-
-import { postRelayerRaw } from '../utils/http.js'
-
+import type { Hex } from 'viem'
 import { CREATE_WALLET_ROUTE } from '../constants.js'
 import type { Config } from '../createConfig.js'
+import { BaseError } from '../errors/base.js'
+import { postRelayerRaw } from '../utils/http.js'
+import { getSkRoot } from './getSkRoot.js'
+import { getWalletId } from './getWalletId.js'
+import { waitForWalletIndexing } from './waitForWalletIndexing.js'
 
-export type CreateWalletReturnType = Promise<{
-  taskId: string
-  walletId: string
-}>
+export type CreateWalletParameters = { seed?: Hex }
 
-export async function createWallet(config: Config): CreateWalletReturnType {
+export type CreateWalletReturnType = ReturnType<typeof waitForWalletIndexing>
+
+export async function createWallet(
+  config: Config,
+  parameters: CreateWalletParameters,
+): CreateWalletReturnType {
   const { getRelayerBaseUrl, utils } = config
+  const { seed } = parameters
   const skRoot = getSkRoot(config)
   const body = utils.create_wallet(skRoot)
   const headers = {
@@ -26,13 +30,39 @@ export async function createWallet(config: Config): CreateWalletReturnType {
   )
   if (res.task_id) {
     config.setState({ ...config.state, status: 'creating wallet' })
-    waitForTaskCompletion(config, { id: res.task_id }).then(() => {
-      config.setState({
-        ...config.state,
-        id: res.wallet_id,
-        status: 'in relayer',
-      })
+    console.log(`task create-wallet(${res.taskId}): ${res.walletId}`, {
+      status: 'creating wallet',
+      walletId: res.wallet_id,
+    })
+    return waitForWalletIndexing(config, {
+      isLookup: false,
+      onComplete: (wallet) => {
+        config.setState({
+          ...config.state,
+          id: wallet.id,
+          status: 'in relayer',
+        })
+        console.log(
+          `task create-wallet(${res.task_id}) completed: ${wallet.id}`,
+          {
+            status: 'in relayer',
+            walletId: wallet.id,
+          },
+        )
+      },
+      onFailure: () => {
+        const walletId = getWalletId(config, { seed })
+        console.error(`wallet id: ${walletId} creating wallet failed`, {
+          status: 'creating wallet',
+          walletId,
+        })
+        config.setState({
+          status: 'disconnected',
+          id: undefined,
+          seed: undefined,
+        })
+      },
     })
   }
-  return { walletId: res.wallet_id, taskId: res.task_id }
+  return Promise.reject(new BaseError('Failed to create wallet'))
 }

--- a/packages/core/src/actions/waitForWalletIndexing.ts
+++ b/packages/core/src/actions/waitForWalletIndexing.ts
@@ -1,0 +1,47 @@
+import type { Hex } from 'viem'
+import { BaseError } from '../errors/base.js'
+import type { Config } from '../createConfig.js'
+import type { Wallet } from '../types/wallet.js'
+import { getWalletFromRelayer } from './getWalletFromRelayer.js'
+
+export type WaitForWalletIndexParameters = {
+  seed?: Hex
+  onComplete?: (wallet: Wallet) => void
+  onFailure?: () => void
+  timeout?: number
+  isLookup?: boolean
+}
+
+export type WaitForWalletIndexReturnType = Promise<void>
+
+export async function waitForWalletIndexing(
+  config: Config,
+  parameters: WaitForWalletIndexParameters,
+): WaitForWalletIndexReturnType {
+  const { pollingInterval } = config
+  const { seed, onComplete, onFailure, timeout = 60000, isLookup } = parameters
+
+  const startTime = Date.now()
+
+  while (true) {
+    if (Date.now() - startTime >= timeout) {
+      onFailure?.()
+      throw new BaseError(
+        `Timed out while ${isLookup ? 'looking up' : 'creating'} wallet`,
+      )
+    }
+
+    try {
+      const wallet = await getWalletFromRelayer(config, { seed })
+      if (wallet) {
+        onComplete?.(wallet)
+        break
+      }
+    } catch (_) {
+      // Do nothing, just continue the loop
+    }
+
+    // Sleep for a bit before polling again
+    await new Promise((resolve) => setTimeout(resolve, pollingInterval / 2))
+  }
+}


### PR DESCRIPTION
This PR adds `waitForWalletIndexing` which is used during the onboarding step to ensure that the internal state of the SDK is correctly updated when wallets are indexed, or created, in the connected relayer. Previously, incorrect states were being reached because we were checking the completion of the `lookup-wallet` or `create-wallet` task.