### PR TITLE
core, react: add back of queue queries

### DIFF
--- a/packages/core/src/actions/createOrder.ts
+++ b/packages/core/src/actions/createOrder.ts
@@ -1,13 +1,12 @@
 import { toHex, type Address } from 'viem'
 
-import { getBackOfQueueWallet } from './getBackOfQueueWallet.js'
-import { getWalletId } from './getWalletId.js'
-import { BaseError } from '../errors/base.js'
-import { postRelayerWithAuth } from '../utils/http.js'
-import { MAX_BALANCES, WALLET_ORDERS_ROUTE } from '../constants.js'
+import { WALLET_ORDERS_ROUTE } from '../constants.js'
 import type { Config } from '../createConfig.js'
 import { Token } from '../types/token.js'
 import { parseBigJSON, stringifyForWasm } from '../utils/bigJSON.js'
+import { postRelayerWithAuth } from '../utils/http.js'
+import { getBackOfQueueWallet } from './getBackOfQueueWallet.js'
+import { getWalletId } from './getWalletId.js'
 
 export type CreateOrderParameters = {
   id?: string
@@ -29,18 +28,6 @@ export async function createOrder(
   const walletId = getWalletId(config)
   const wallet = await getBackOfQueueWallet(config)
 
-  // If the order would result in more than 5 balances, panic
-  const filteredWallet = await getBackOfQueueWallet(config, {
-    filterDefaults: true,
-  })
-  const balances = filteredWallet?.balances
-  if (
-    side === 'buy' &&
-    balances?.length === MAX_BALANCES &&
-    !balances.find((b) => b.mint === base)
-  ) {
-    throw new BaseError('Order would result in too many balances')
-  }
 
   const body = utils.new_order(
     stringifyForWasm(wallet),

--- a/packages/core/src/actions/deposit.ts
+++ b/packages/core/src/actions/deposit.ts
@@ -1,9 +1,8 @@
 import invariant from 'tiny-invariant'
 import { toHex, type Address } from 'viem'
 
-import { DEPOSIT_BALANCE_ROUTE, MAX_BALANCES } from '../constants.js'
+import { DEPOSIT_BALANCE_ROUTE } from '../constants.js'
 import type { Config } from '../createConfig.js'
-import { BaseError } from '../errors/base.js'
 import { Token } from '../types/token.js'
 import { parseBigJSON, stringifyForWasm } from '../utils/bigJSON.js'
 import { postRelayerWithAuth } from '../utils/http.js'
@@ -34,26 +33,6 @@ export async function deposit(
 
   const walletId = getWalletId(config)
   const wallet = await getBackOfQueueWallet(config)
-
-  // If deposit would result in > 5 balances, including potential balance from buy order, throw
-  const filteredWallet = await getBackOfQueueWallet(config, {
-    filterDefaults: true,
-  })
-  const balances = filteredWallet?.balances
-  const mints = balances?.map((balance) => balance.mint)
-  const isNewBalance = !mints?.includes(mint)
-  const orders = filteredWallet?.orders
-  const orderThatWouldResultInNewBalance = orders?.find((order) => {
-    return order.side === 'Buy' && !mints?.includes(order.base_mint)
-  })
-
-  if (
-    balances?.length === MAX_BALANCES - 1 &&
-    isNewBalance &&
-    orderThatWouldResultInNewBalance?.amount
-  ) {
-    throw new BaseError('Buy order would result in more than 5 balances')
-  }
 
   const body = utils.deposit(
     stringifyForWasm(wallet),

--- a/packages/core/src/actions/getBackOfQueueWallet.ts
+++ b/packages/core/src/actions/getBackOfQueueWallet.ts
@@ -1,23 +1,24 @@
 import type { Hex } from 'viem'
-import { getSkRoot } from './getSkRoot.js'
-
-import { getRelayerWithAuth } from '../utils/http.js'
-
 import { BACK_OF_QUEUE_WALLET_ROUTE } from '../constants.js'
 import type { Config } from '../createConfig.js'
+import { BaseError, type BaseErrorType } from '../errors/base.js'
 import type { Balance, Order, Wallet } from '../types/wallet.js'
+import { getRelayerWithAuth } from '../utils/http.js'
+import { getSkRoot } from './getSkRoot.js'
 
 export type GetBackOfQueueWalletParameters = {
   seed?: Hex
   filterDefaults?: boolean
 }
 
-export type GetBackOfQueueWalletReturnType = Promise<Wallet | undefined>
+export type GetBackOfQueueWalletReturnType = Wallet
+
+export type GetBackOfQueueWalletErrorType = BaseErrorType
 
 export async function getBackOfQueueWallet(
   config: Config,
   parameters: GetBackOfQueueWalletParameters = {},
-): GetBackOfQueueWalletReturnType {
+): Promise<GetBackOfQueueWalletReturnType> {
   const { filterDefaults, seed } = parameters
   const { getRelayerBaseUrl, utils } = config
   const skRoot = getSkRoot(config, { seed })
@@ -26,6 +27,9 @@ export async function getBackOfQueueWallet(
     config,
     getRelayerBaseUrl(BACK_OF_QUEUE_WALLET_ROUTE(walletId)),
   )
+  if (!res.wallet) {
+    throw new BaseError('Back of queue wallet not found')
+  }
   if (filterDefaults) {
     return {
       ...res.wallet,

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -5,6 +5,9 @@ import type { Address } from 'viem'
 export const RENEGADE_AUTH_HEADER_NAME = 'renegade-auth'
 /// Header name for the expiration timestamp of a signature
 export const RENEGADE_SIG_EXPIRATION_HEADER_NAME = 'renegade-auth-expiration'
+/// The message used to derive the wallet's root key
+export const ROOT_KEY_MESSAGE_PREFIX =
+  'Unlock your Renegade Wallet on chain ID:'
 
 ////////////////////////////////////////////////////////////////////////////////
 // System-Wide Constants

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -230,6 +230,15 @@ export { chain } from './utils/viem.js'
 export { hashFn, structuralSharing } from './query/utils.js'
 
 export {
+  type GetBackOfQueueWalletData,
+  type GetBackOfQueueWalletOptions,
+  type GetBackOfQueueWalletQueryFnData,
+  type GetBackOfQueueWalletQueryKey,
+  getBackOfQueueWalletQueryKey,
+  getBackOfQueueWalletQueryOptions,
+} from './query/getBackOfQueueWallet.js'
+
+export {
   type GetWalletData,
   type GetWalletOptions,
   type GetWalletQueryFnData,

--- a/packages/core/src/query/getBackOfQueueWallet.ts
+++ b/packages/core/src/query/getBackOfQueueWallet.ts
@@ -1,0 +1,52 @@
+import type { QueryOptions } from '@tanstack/query-core'
+import {
+  getBackOfQueueWallet,
+  type GetBackOfQueueWalletErrorType,
+  type GetBackOfQueueWalletParameters,
+  type GetBackOfQueueWalletReturnType,
+} from '../actions/getBackOfQueueWallet.js'
+import type { Config } from '../createConfig.js'
+import type { Evaluate, PartialBy } from '../types/utils.js'
+import { filterQueryOptions, type ScopeKeyParameter } from './utils.js'
+
+export type GetBackOfQueueWalletOptions = Evaluate<
+  PartialBy<GetBackOfQueueWalletParameters, 'seed'> & ScopeKeyParameter
+>
+
+export function getBackOfQueueWalletQueryOptions(
+  config: Config,
+  options: GetBackOfQueueWalletOptions = {},
+) {
+  return {
+    async queryFn({ queryKey }) {
+      const { seed, scopeKey: _, ...parameters } = queryKey[1]
+      if (!seed) throw new Error('seed is required')
+      const wallet = await getBackOfQueueWallet(config, {
+        ...(parameters as GetBackOfQueueWalletParameters),
+        seed,
+      })
+      return wallet ?? null
+    },
+    queryKey: getBackOfQueueWalletQueryKey(options),
+  } as const satisfies QueryOptions<
+    GetBackOfQueueWalletQueryFnData,
+    GetBackOfQueueWalletErrorType,
+    GetBackOfQueueWalletData,
+    GetBackOfQueueWalletQueryKey
+  >
+}
+
+export type GetBackOfQueueWalletQueryFnData =
+  Evaluate<GetBackOfQueueWalletReturnType>
+
+export type GetBackOfQueueWalletData = GetBackOfQueueWalletQueryFnData
+
+export function getBackOfQueueWalletQueryKey(
+  options: GetBackOfQueueWalletOptions = {},
+) {
+  return ['backOfQueueWallet', filterQueryOptions(options)] as const
+}
+
+export type GetBackOfQueueWalletQueryKey = ReturnType<
+  typeof getBackOfQueueWalletQueryKey
+>

--- a/packages/react/src/hooks/useBackOfQueueBalances.ts
+++ b/packages/react/src/hooks/useBackOfQueueBalances.ts
@@ -1,0 +1,25 @@
+'use client'
+
+import type { Balance, Config } from '@renegade-fi/core'
+import { useBackOfQueueWallet } from './useBackOfQueueWallet.js'
+
+export type UseBackOfQueueBalancesParameters = {
+  config?: Config
+  filter?: boolean
+}
+
+export type UseBackOfQueueBalancesReturnType = Balance[]
+
+export function useBackOfQueueBalances(
+  parameters: UseBackOfQueueBalancesParameters = {},
+): UseBackOfQueueBalancesReturnType {
+  const { filter = true } = parameters
+  const { data: wallet } = useBackOfQueueWallet()
+  if (!wallet) return []
+  if (filter) {
+    return wallet.balances.filter(
+      (balance) => balance.mint !== '0x0' && balance.amount,
+    )
+  }
+  return wallet.balances
+}

--- a/packages/react/src/hooks/useBackOfQueueOrders.ts
+++ b/packages/react/src/hooks/useBackOfQueueOrders.ts
@@ -1,0 +1,23 @@
+'use client'
+
+import type { Config, Order } from '@renegade-fi/core'
+import { useBackOfQueueWallet } from './useBackOfQueueWallet.js'
+
+export type UseBackOfQueueOrdersParameters = {
+  config?: Config
+  filter?: boolean
+}
+
+export type UseBackOfQueueOrdersReturnType = Order[]
+
+export function useBackOfQueueOrders(
+  parameters: UseBackOfQueueOrdersParameters = {},
+): UseBackOfQueueOrdersReturnType {
+  const { filter = true } = parameters
+  const { data: wallet } = useBackOfQueueWallet()
+  if (!wallet) return []
+  if (filter) {
+    return wallet.orders.filter((order) => order.amount > 0)
+  }
+  return wallet.orders
+}

--- a/packages/react/src/hooks/useBackOfQueueWallet.ts
+++ b/packages/react/src/hooks/useBackOfQueueWallet.ts
@@ -1,0 +1,66 @@
+'use client'
+
+import {
+  getBackOfQueueWalletQueryOptions,
+  type Evaluate,
+  type GetBackOfQueueWalletData,
+  type GetBackOfQueueWalletOptions,
+  type GetBackOfQueueWalletQueryFnData,
+  type GetBackOfQueueWalletQueryKey,
+} from '@renegade-fi/core'
+import { useQueryClient } from '@tanstack/react-query'
+import type { ConfigParameter, QueryParameter } from '../types/properties.js'
+import { useQuery, type UseQueryReturnType } from '../utils/query.js'
+import { useConfig } from './useConfig.js'
+import { useStatus } from './useStatus.js'
+import { useWalletWebsocket } from './useWalletWebSocket.js'
+import type { GetBackOfQueueWalletErrorType } from '@renegade-fi/core/dist/types/actions/getBackOfQueueWallet.js'
+
+export type UseBackOfQueueWalletParameters<
+  selectData = GetBackOfQueueWalletData,
+> = Evaluate<
+  GetBackOfQueueWalletOptions &
+    ConfigParameter &
+    QueryParameter<
+      GetBackOfQueueWalletQueryFnData,
+      GetBackOfQueueWalletErrorType,
+      selectData,
+      GetBackOfQueueWalletQueryKey
+    >
+>
+
+export type UseBackOfQueueWalletReturnType<
+  selectData = GetBackOfQueueWalletData,
+> = UseQueryReturnType<selectData, GetBackOfQueueWalletErrorType>
+
+export function useBackOfQueueWallet<selectData = GetBackOfQueueWalletData>(
+  parameters: UseBackOfQueueWalletParameters<selectData> = {},
+): UseBackOfQueueWalletReturnType<selectData> {
+  const { filterDefaults, seed, query = {} } = parameters
+
+  const config = useConfig(parameters)
+  const status = useStatus(parameters)
+  const queryClient = useQueryClient()
+
+  const options = getBackOfQueueWalletQueryOptions(config, {
+    ...parameters,
+    seed: seed ?? config.state.seed,
+    filterDefaults,
+  })
+  const enabled = Boolean(
+    status === 'in relayer' &&
+      (seed || config.state.seed) &&
+      (query.enabled ?? true),
+  )
+
+  useWalletWebsocket({
+    enabled,
+    onUpdate: (wallet) => {
+      if (wallet && queryClient && options.queryKey) {
+        queryClient.setQueryData(options.queryKey, wallet)
+      }
+    },
+  })
+
+  return useQuery({ ...query, ...options, enabled })
+}

--- a/packages/react/src/hooks/useNetworkOrders.ts
+++ b/packages/react/src/hooks/useNetworkOrders.ts
@@ -63,5 +63,11 @@ export function useNetworkOrders<selectData = GetNetworkOrdersData>(
   })
 
   // Disable refetch to prevent flickering in multinode cluster (orderbook is not part of consensus)
-  return useQuery({ ...query, ...options, enabled, refetchInterval: false, refetchOnWindowFocus: false })
+  return useQuery({
+    ...query,
+    ...options,
+    enabled,
+    refetchInterval: false,
+    refetchOnWindowFocus: false,
+  })
 }


### PR DESCRIPTION
This PR adds queries for back of queue API endpoints. Also removes safety checks in deposit and create order actions since they are now implemented in the frontend.