### PR TITLE
core: remove placeholder block explorer url

### DIFF
--- a/packages/core/src/utils/viem.ts
+++ b/packages/core/src/utils/viem.ts
@@ -24,15 +24,6 @@ export const chain = defineChain({
     default: {
       http: [rpcURL],
     },
-    public: {
-      http: [rpcURL],
-    },
-  },
-  blockExplorers: {
-    default: {
-      name: 'Explorer',
-      url: 'https://explorer.renegade.fi/',
-    },
   },
 })
 


### PR DESCRIPTION
This PR removes the placeholder block explorer URL.

Tested in frontend that the network is still automatically added.