### PR TITLE
core: add refresh wallet task

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,15 +40,9 @@
   },
   "typesVersions": {
     "*": {
-      "actions": [
-        "./dist/types/exports/actions.d.ts"
-      ],
-      "constants": [
-        "./dist/types/exports/constants.d.ts"
-      ],
-      "query": [
-        "./dist/types/exports/query.d.ts"
-      ]
+      "actions": ["./dist/types/exports/actions.d.ts"],
+      "constants": ["./dist/types/exports/constants.d.ts"],
+      "query": ["./dist/types/exports/query.d.ts"]
     }
   },
   "peerDependencies": {

--- a/packages/core/src/actions/refreshWallet.ts
+++ b/packages/core/src/actions/refreshWallet.ts
@@ -1,0 +1,35 @@
+import { REFRESH_WALLET_ROUTE } from '../constants.js'
+import type { Config } from '../createConfig.js'
+import { postRelayerWithAuth } from '../utils/http.js'
+import { getWalletId } from './getWalletId.js'
+
+export type RefreshWalletReturnType = Promise<{ taskId: string }>
+
+export async function refreshWallet(config: Config): RefreshWalletReturnType {
+  const { getRelayerBaseUrl } = config
+  const walletId = getWalletId(config)
+
+  const logContext = {
+    walletId,
+  }
+
+  try {
+    const res = await postRelayerWithAuth(
+      config,
+      getRelayerBaseUrl(REFRESH_WALLET_ROUTE(walletId)),
+    )
+    if (res?.task_id) {
+      console.log(
+        `task refresh-wallet(${res.task_id}): ${walletId}`,
+        logContext,
+      )
+    }
+    return { taskId: res.task_id }
+  } catch (error) {
+    console.error(`wallet id: ${walletId} refresh wallet failed`, {
+      error,
+      ...logContext,
+    })
+    throw error
+  }
+}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -27,6 +27,9 @@ export const MAX_ORDERS = 5
 export const CREATE_WALLET_ROUTE = '/wallet'
 // Find a wallet in contract storage
 export const FIND_WALLET_ROUTE = '/wallet/lookup'
+// Refresh a wallet from on-chain state
+export const REFRESH_WALLET_ROUTE = (wallet_id: string) =>
+  `/wallet/${wallet_id}/refresh`
 // Returns the wallet information for the given id
 export const GET_WALLET_ROUTE = (wallet_id: string) => `/wallet/${wallet_id}`
 /// Get the wallet at the "back of the queue", i.e. the speculatively updated

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -134,6 +134,11 @@ export {
 export { type PayFeesReturnType, payFees } from '../actions/payFees.js'
 
 export {
+  type RefreshWalletReturnType,
+  refreshWallet,
+} from '../actions/refreshWallet.js'
+
+export {
   type SignMessageParameters,
   type SignMessageReturnType,
   signMessage,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,15 +41,9 @@
   },
   "typesVersions": {
     "*": {
-      "actions": [
-        "./dist/types/exports/actions.d.ts"
-      ],
-      "constants": [
-        "./dist/types/exports/constants.d.ts"
-      ],
-      "query": [
-        "./dist/types/exports/query.d.ts"
-      ]
+      "actions": ["./dist/types/exports/actions.d.ts"],
+      "constants": ["./dist/types/exports/constants.d.ts"],
+      "query": ["./dist/types/exports/query.d.ts"]
     }
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,7 +107,7 @@ importers:
   packages/test:
     dependencies:
       '@renegade-fi/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
 
 packages:


### PR DESCRIPTION
This PR adds the action for `refresh-wallet` as defined in https://github.com/renegade-fi/renegade/pull/657 