### PR TITLE
core: increase lookup wallet timeout

### DIFF
--- a/packages/core/src/actions/lookupWallet.ts
+++ b/packages/core/src/actions/lookupWallet.ts
@@ -28,6 +28,7 @@ export async function lookupWallet(
     })
     config.setState({ ...config.state, status: 'looking up' })
     return waitForWalletIndexing(config, {
+      timeout: 300000,
       isLookup: true,
       onComplete(wallet) {
         config.setState({


### PR DESCRIPTION
This PR increases the timeout to wait for lookup wallet indexing to 5 min.