### PR TITLE
core, react: remove unecessary `seed` parameter, safeguard state transitions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,15 +40,9 @@
   },
   "typesVersions": {
     "*": {
-      "actions": [
-        "./dist/types/exports/actions.d.ts"
-      ],
-      "constants": [
-        "./dist/types/exports/constants.d.ts"
-      ],
-      "query": [
-        "./dist/types/exports/query.d.ts"
-      ]
+      "actions": ["./dist/types/exports/actions.d.ts"],
+      "constants": ["./dist/types/exports/constants.d.ts"],
+      "query": ["./dist/types/exports/query.d.ts"]
     }
   },
   "peerDependencies": {

--- a/packages/core/src/actions/disconnect.ts
+++ b/packages/core/src/actions/disconnect.ts
@@ -3,5 +3,5 @@ import type { Config } from '../createConfig.js'
 export type DisconnectReturnType = Promise<void>
 
 export async function disconnect(config: Config): DisconnectReturnType {
-  config.setState({ status: 'disconnected', id: undefined, seed: undefined })
+  config.setState({})
 }

--- a/packages/core/src/actions/getBackOfQueueWallet.ts
+++ b/packages/core/src/actions/getBackOfQueueWallet.ts
@@ -1,4 +1,3 @@
-import type { Hex } from 'viem'
 import { BACK_OF_QUEUE_WALLET_ROUTE } from '../constants.js'
 import type { Config } from '../createConfig.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
@@ -7,7 +6,6 @@ import { getRelayerWithAuth } from '../utils/http.js'
 import { getSkRoot } from './getSkRoot.js'
 
 export type GetBackOfQueueWalletParameters = {
-  seed?: Hex
   filterDefaults?: boolean
 }
 
@@ -19,9 +17,9 @@ export async function getBackOfQueueWallet(
   config: Config,
   parameters: GetBackOfQueueWalletParameters = {},
 ): Promise<GetBackOfQueueWalletReturnType> {
-  const { filterDefaults, seed } = parameters
+  const { filterDefaults } = parameters
   const { getRelayerBaseUrl, utils } = config
-  const skRoot = getSkRoot(config, { seed })
+  const skRoot = getSkRoot(config)
   const walletId = utils.wallet_id(skRoot)
   const res = await getRelayerWithAuth(
     config,

--- a/packages/core/src/actions/getSkRoot.ts
+++ b/packages/core/src/actions/getSkRoot.ts
@@ -1,24 +1,11 @@
 import invariant from 'tiny-invariant'
 import type { Hex } from 'viem'
-
 import type { Config } from '../createConfig.js'
-
-export type GetSkRootParameters = {
-  seed?: Hex
-}
 
 export type GetSkRootReturnType = Hex
 
-export function getSkRoot(
-  config: Config,
-  parameters: GetSkRootParameters = {},
-): GetSkRootReturnType {
-  const { seed } = parameters
+export function getSkRoot(config: Config): GetSkRootReturnType {
   const { utils } = config
-  if (seed) {
-    config.setState({ ...config.state, seed })
-    return utils.derive_signing_key_from_seed(seed)
-  }
   const storedSeed = config.state.seed
   invariant(storedSeed, 'Seed must be defined when none exists in memory')
   return utils.derive_signing_key_from_seed(storedSeed)

--- a/packages/core/src/actions/getWalletFromRelayer.ts
+++ b/packages/core/src/actions/getWalletFromRelayer.ts
@@ -1,15 +1,11 @@
-import type { Hex } from 'viem'
-import { getSkRoot } from './getSkRoot.js'
-
-import { getRelayerWithAuth } from '../utils/http.js'
-
 import { GET_WALLET_ROUTE } from '../constants.js'
 import type { Config } from '../createConfig.js'
-import type { Balance, Order, Wallet } from '../types/wallet.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
+import type { Balance, Order, Wallet } from '../types/wallet.js'
+import { getRelayerWithAuth } from '../utils/http.js'
+import { getSkRoot } from './getSkRoot.js'
 
 export type GetWalletFromRelayerParameters = {
-  seed?: Hex
   filterDefaults?: boolean
 }
 
@@ -21,9 +17,9 @@ export async function getWalletFromRelayer(
   config: Config,
   parameters: GetWalletFromRelayerParameters = {},
 ): Promise<GetWalletFromRelayerReturnType> {
-  const { filterDefaults, seed } = parameters
+  const { filterDefaults } = parameters
   const { getRelayerBaseUrl, utils } = config
-  const skRoot = getSkRoot(config, { seed })
+  const skRoot = getSkRoot(config)
   const walletId = utils.wallet_id(skRoot)
   const res = await getRelayerWithAuth(
     config,
@@ -32,11 +28,10 @@ export async function getWalletFromRelayer(
   if (!res.wallet) {
     throw new BaseError('Wallet not found')
   }
-  config.setState({
-    ...config.state,
+  config.setState((x) => ({
+    ...x,
     status: 'in relayer',
-    id: res.wallet.id,
-  })
+  }))
   if (filterDefaults) {
     return {
       ...res.wallet,

--- a/packages/core/src/actions/getWalletId.ts
+++ b/packages/core/src/actions/getWalletId.ts
@@ -1,19 +1,11 @@
-import type { Hex } from 'viem'
-import { getSkRoot } from './getSkRoot.js'
-
 import type { Config } from '../createConfig.js'
-
-export type GetWalletIdParameters = { seed?: Hex }
+import { getSkRoot } from './getSkRoot.js'
 
 export type GetWalletIdReturnType = string
 
-export function getWalletId(
-  config: Config,
-  parameters: GetWalletIdParameters = {},
-): GetWalletIdReturnType {
+export function getWalletId(config: Config): GetWalletIdReturnType {
   const { utils } = config
-  const { seed } = parameters
-  const skRoot = getSkRoot(config, { seed })
+  const skRoot = getSkRoot(config)
   const walletId = utils.wallet_id(skRoot)
   return walletId
 }

--- a/packages/core/src/actions/waitForWalletIndexing.ts
+++ b/packages/core/src/actions/waitForWalletIndexing.ts
@@ -1,11 +1,9 @@
-import type { Hex } from 'viem'
-import { BaseError } from '../errors/base.js'
 import type { Config } from '../createConfig.js'
+import { BaseError } from '../errors/base.js'
 import type { Wallet } from '../types/wallet.js'
 import { getWalletFromRelayer } from './getWalletFromRelayer.js'
 
 export type WaitForWalletIndexParameters = {
-  seed?: Hex
   onComplete?: (wallet: Wallet) => void
   onFailure?: () => void
   timeout?: number
@@ -19,7 +17,7 @@ export async function waitForWalletIndexing(
   parameters: WaitForWalletIndexParameters,
 ): WaitForWalletIndexReturnType {
   const { pollingInterval } = config
-  const { seed, onComplete, onFailure, timeout = 60000, isLookup } = parameters
+  const { onComplete, onFailure, timeout = 60000, isLookup } = parameters
 
   const startTime = Date.now()
 
@@ -32,7 +30,7 @@ export async function waitForWalletIndexing(
     }
 
     try {
-      const wallet = await getWalletFromRelayer(config, { seed })
+      const wallet = await getWalletFromRelayer(config)
       if (wallet) {
         onComplete?.(wallet)
         break

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -9,7 +9,6 @@ export {
 } from '../actions/cancelOrder.js'
 
 export {
-  type ConnectParameters,
   type ConnectReturnType,
   connect,
 } from '../actions/connect.js'
@@ -96,7 +95,6 @@ export {
 } from '../actions/getPriceFromPriceReporter.js'
 
 export {
-  type GetSkRootParameters,
   type GetSkRootReturnType,
   getSkRoot,
 } from '../actions/getSkRoot.js'
@@ -126,13 +124,11 @@ export {
 } from '../actions/getWalletFromRelayer.js'
 
 export {
-  type GetWalletIdParameters,
   type GetWalletIdReturnType,
   getWalletId,
 } from '../actions/getWalletId.js'
 
 export {
-  type LookupWalletParameters,
   type LookupWalletReturnType,
   lookupWallet,
 } from '../actions/lookupWallet.js'

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -9,7 +9,6 @@ export {
 } from '../actions/cancelOrder.js'
 
 export {
-  type ConnectParameters,
   type ConnectReturnType,
   connect,
 } from '../actions/connect.js'
@@ -91,7 +90,6 @@ export {
 } from '../actions/getPriceFromPriceReporter.js'
 
 export {
-  type GetSkRootParameters,
   type GetSkRootReturnType,
   getSkRoot,
 } from '../actions/getSkRoot.js'
@@ -121,13 +119,11 @@ export {
 } from '../actions/getWalletFromRelayer.js'
 
 export {
-  type GetWalletIdParameters,
   type GetWalletIdReturnType,
   getWalletId,
 } from '../actions/getWalletId.js'
 
 export {
-  type LookupWalletParameters,
   type LookupWalletReturnType,
   lookupWallet,
 } from '../actions/lookupWallet.js'

--- a/packages/core/src/hydrate.ts
+++ b/packages/core/src/hydrate.ts
@@ -25,8 +25,7 @@ export function hydrate(config: Config, parameters: HydrateParameters) {
       }
 
       if (reconnectOnMount) {
-        console.log('🚝 Reconnecting on mount')
-        reconnect(config, { id: config.state.id })
+        reconnect(config)
       }
     },
   }

--- a/packages/core/src/query/getBackOfQueueWallet.ts
+++ b/packages/core/src/query/getBackOfQueueWallet.ts
@@ -6,12 +6,11 @@ import {
   type GetBackOfQueueWalletReturnType,
 } from '../actions/getBackOfQueueWallet.js'
 import type { Config } from '../createConfig.js'
-import type { Evaluate, PartialBy } from '../types/utils.js'
+import type { Evaluate } from '../types/utils.js'
 import { filterQueryOptions, type ScopeKeyParameter } from './utils.js'
 
-export type GetBackOfQueueWalletOptions = Evaluate<
-  PartialBy<GetBackOfQueueWalletParameters, 'seed'> & ScopeKeyParameter
->
+export type GetBackOfQueueWalletOptions =
+  Evaluate<GetBackOfQueueWalletParameters> & ScopeKeyParameter
 
 export function getBackOfQueueWalletQueryOptions(
   config: Config,
@@ -19,11 +18,9 @@ export function getBackOfQueueWalletQueryOptions(
 ) {
   return {
     async queryFn({ queryKey }) {
-      const { seed, scopeKey: _, ...parameters } = queryKey[1]
-      if (!seed) throw new Error('seed is required')
+      const { scopeKey: _, ...parameters } = queryKey[1]
       const wallet = await getBackOfQueueWallet(config, {
         ...(parameters as GetBackOfQueueWalletParameters),
-        seed,
       })
       return wallet ?? null
     },

--- a/packages/core/src/query/getWallet.ts
+++ b/packages/core/src/query/getWallet.ts
@@ -6,11 +6,11 @@ import {
   type GetWalletFromRelayerReturnType,
 } from '../actions/getWalletFromRelayer.js'
 import type { Config } from '../createConfig.js'
-import type { Evaluate, PartialBy } from '../types/utils.js'
+import type { Evaluate } from '../types/utils.js'
 import { filterQueryOptions, type ScopeKeyParameter } from './utils.js'
 
 export type GetWalletOptions = Evaluate<
-  PartialBy<GetWalletFromRelayerParameters, 'seed'> & ScopeKeyParameter
+  GetWalletFromRelayerParameters & ScopeKeyParameter
 >
 
 export function getWalletQueryOptions(
@@ -19,11 +19,9 @@ export function getWalletQueryOptions(
 ) {
   return {
     async queryFn({ queryKey }) {
-      const { seed, scopeKey: _, ...parameters } = queryKey[1]
-      if (!seed) throw new Error('seed is required')
+      const { scopeKey: _, ...parameters } = queryKey[1]
       const wallet = await getWalletFromRelayer(config, {
         ...(parameters as GetWalletFromRelayerParameters),
-        seed,
       })
       return wallet ?? null
     },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,15 +41,9 @@
   },
   "typesVersions": {
     "*": {
-      "actions": [
-        "./dist/types/exports/actions.d.ts"
-      ],
-      "constants": [
-        "./dist/types/exports/constants.d.ts"
-      ],
-      "query": [
-        "./dist/types/exports/query.d.ts"
-      ]
+      "actions": ["./dist/types/exports/actions.d.ts"],
+      "constants": ["./dist/types/exports/constants.d.ts"],
+      "query": ["./dist/types/exports/query.d.ts"]
     }
   },
   "peerDependencies": {

--- a/packages/react/src/hooks/useBackOfQueueWallet.ts
+++ b/packages/react/src/hooks/useBackOfQueueWallet.ts
@@ -35,7 +35,7 @@ export type UseBackOfQueueWalletReturnType<
 export function useBackOfQueueWallet<selectData = GetBackOfQueueWalletData>(
   parameters: UseBackOfQueueWalletParameters<selectData> = {},
 ): UseBackOfQueueWalletReturnType<selectData> {
-  const { filterDefaults, seed, query = {} } = parameters
+  const { filterDefaults, query = {} } = parameters
 
   const config = useConfig(parameters)
   const status = useStatus(parameters)
@@ -43,13 +43,10 @@ export function useBackOfQueueWallet<selectData = GetBackOfQueueWalletData>(
 
   const options = getBackOfQueueWalletQueryOptions(config, {
     ...parameters,
-    seed: seed ?? config.state.seed,
     filterDefaults,
   })
   const enabled = Boolean(
-    status === 'in relayer' &&
-      (seed || config.state.seed) &&
-      (query.enabled ?? true),
+    status === 'in relayer' && config.state.seed && (query.enabled ?? true),
   )
 
   useWalletWebsocket({

--- a/packages/react/src/hooks/useWallet.ts
+++ b/packages/react/src/hooks/useWallet.ts
@@ -32,7 +32,7 @@ export type UseWalletReturnType<selectData = GetWalletData> =
 export function useWallet<selectData = GetWalletData>(
   parameters: UseWalletParameters<selectData> = {},
 ): UseWalletReturnType<selectData> {
-  const { filterDefaults, seed, query = {} } = parameters
+  const { filterDefaults, query = {} } = parameters
 
   const config = useConfig(parameters)
   const status = useStatus(parameters)
@@ -40,13 +40,10 @@ export function useWallet<selectData = GetWalletData>(
 
   const options = getWalletQueryOptions(config, {
     ...parameters,
-    seed: seed ?? config.state.seed,
     filterDefaults,
   })
   const enabled = Boolean(
-    status === 'in relayer' &&
-      (seed || config.state.seed) &&
-      (query.enabled ?? true),
+    status === 'in relayer' && config.state.seed && (query.enabled ?? true),
   )
 
   useWalletWebsocket({


### PR DESCRIPTION
This PR adds checks in the `setState` function to prevent invalid state transitions. Also removes the `seed` parameter from functions, opting to instead use the seed stored in state on the `config` object.