### PR TITLE
core: downstream API changes for orders / tasks

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -3,6 +3,7 @@
     "ignore": [
       "CHANGELOG.md",
       "pnpm-lock.yaml",
+      "package.json",
       "tsconfig.base.json",
       "wasm/**",
       "dist/**",

--- a/packages/core/src/actions/getBackOfQueueWallet.ts
+++ b/packages/core/src/actions/getBackOfQueueWallet.ts
@@ -1,7 +1,8 @@
 import { BACK_OF_QUEUE_WALLET_ROUTE } from '../constants.js'
 import type { Config } from '../createConfig.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
-import type { Balance, Order, Wallet } from '../types/wallet.js'
+import type { Order } from '../types/order.js'
+import type { Balance, Wallet } from '../types/wallet.js'
 import { getRelayerWithAuth } from '../utils/http.js'
 import { getSkRoot } from './getSkRoot.js'
 

--- a/packages/core/src/actions/getOrder.ts
+++ b/packages/core/src/actions/getOrder.ts
@@ -1,19 +1,17 @@
-import { getSkRoot } from './getSkRoot.js'
-
-import { getRelayerWithAuth } from '../utils/http.js'
-
 import { GET_ORDER_BY_ID_ROUTE } from '../constants.js'
 import type { Config } from '../createConfig.js'
-import type { Order } from '../types/wallet.js'
+import type { Order } from '../types/order.js'
+import { getRelayerWithAuth } from '../utils/http.js'
+import { getSkRoot } from './getSkRoot.js'
 
 export type GetOrderParameters = { id: string }
 
-export type GetOrderReturnType = Promise<Order>
+export type GetOrderReturnType = Order
 
 export async function getOrder(
   config: Config,
   parameters: GetOrderParameters,
-): GetOrderReturnType {
+): Promise<GetOrderReturnType> {
   const { id } = parameters
   const { getRelayerBaseUrl, utils } = config
   const skRoot = getSkRoot(config)

--- a/packages/core/src/actions/getOrderHistory.ts
+++ b/packages/core/src/actions/getOrderHistory.ts
@@ -1,11 +1,9 @@
-import { getSkRoot } from './getSkRoot.js'
-
-import { getRelayerWithAuth } from '../utils/http.js'
-
 import { ORDER_HISTORY_ROUTE } from '../constants.js'
 import type { Config } from '../createConfig.js'
-import type { OrderMetadata } from '../types/wallet.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
+import type { OrderMetadata } from '../types/order.js'
+import { getRelayerWithAuth } from '../utils/http.js'
+import { getSkRoot } from './getSkRoot.js'
 
 export type GetOrderHistoryReturnType = Map<string, OrderMetadata>
 

--- a/packages/core/src/actions/getOrders.ts
+++ b/packages/core/src/actions/getOrders.ts
@@ -1,14 +1,12 @@
-import { getSkRoot } from './getSkRoot.js'
-
-import { getRelayerWithAuth } from '../utils/http.js'
-
 import { WALLET_ORDERS_ROUTE } from '../constants.js'
 import type { Config } from '../createConfig.js'
-import type { Order } from '../types/wallet.js'
+import type { Order } from '../types/order.js'
+import { getRelayerWithAuth } from '../utils/http.js'
+import { getSkRoot } from './getSkRoot.js'
 
-export type GetOrdersReturnType = Promise<Order[]>
+export type GetOrdersReturnType = Order[]
 
-export async function getOrders(config: Config): GetOrdersReturnType {
+export async function getOrders(config: Config): Promise<GetOrdersReturnType> {
   const { getRelayerBaseUrl, utils } = config
   const skRoot = getSkRoot(config)
   const walletId = utils.wallet_id(skRoot)

--- a/packages/core/src/actions/getWalletFromRelayer.ts
+++ b/packages/core/src/actions/getWalletFromRelayer.ts
@@ -1,7 +1,8 @@
 import { GET_WALLET_ROUTE } from '../constants.js'
 import type { Config } from '../createConfig.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
-import type { Balance, Order, Wallet } from '../types/wallet.js'
+import type { Order } from '../types/order.js'
+import type { Balance, Wallet } from '../types/wallet.js'
 import { getRelayerWithAuth } from '../utils/http.js'
 import { getSkRoot } from './getSkRoot.js'
 

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -194,13 +194,10 @@ export { BaseError } from '../errors/base.js'
 ////////////////////////////////////////////////////////////////////////////////
 
 export { Token } from '../types/token.js'
-
 export * from '../types/wallet.js'
-
+export * from '../types/order.js'
 export * from '../types/utils.js'
-
-export type { Task, TaskInfo, TaskState } from '../types/task.js'
-export { UpdateType, TaskType } from '../types/task.js'
+export * from '../types/task.js'
 
 ////////////////////////////////////////////////////////////////////////////////
 // Utils

--- a/packages/core/src/types/order.ts
+++ b/packages/core/src/types/order.ts
@@ -1,0 +1,34 @@
+export type Order = {
+  id: string
+  quote_mint: `0x${string}`
+  base_mint: `0x${string}`
+  side: 'Buy' | 'Sell'
+  type: string
+  worst_case_price: string
+  amount: bigint
+}
+
+export enum OrderState {
+  Created = 'Created',
+  Matching = 'Matching',
+  SettlingMatch = 'SettlingMatch',
+  Filled = 'Filled',
+  Cancelled = 'Cancelled',
+}
+
+export type OrderMetadata = {
+  id: string
+  state: OrderState
+  fills: PartialOrderFill[]
+  created: bigint
+  data: Order
+}
+
+export type PartialOrderFill = {
+  // The amount filled by the partial fill
+  amount: bigint
+  // The price at which the fill executed
+  price: bigint
+  // The time at which the fill executed, in milliseconds since the epoch
+  timestamp: bigint
+}

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -1,5 +1,3 @@
-import type { Address } from 'viem'
-
 export type Task = {
   id: string
   state: TaskState
@@ -37,40 +35,43 @@ export type TaskInfo =
   | {
       update_type: UpdateType.Deposit
       task_type: TaskType.UpdateWallet
-      mint: Address
+      mint: `0x${string}`
       amount: bigint
     }
   | {
       update_type: UpdateType.Withdraw
       task_type: TaskType.UpdateWallet
-      mint: Address
+      mint: `0x${string}`
       amount: bigint
     }
   | {
       update_type: UpdateType.PlaceOrder
       task_type: TaskType.UpdateWallet
       amount: bigint
-      base: Address
-      quote: Address
+      base: `0x${string}`
+      quote: `0x${string}`
       side: 'Buy' | 'Sell'
     }
   | {
       update_type: UpdateType.CancelOrder
       task_type: TaskType.UpdateWallet
       amount: bigint
-      base: Address
-      quote: Address
+      base: `0x${string}`
+      quote: `0x${string}`
       side: 'Buy' | 'Sell'
     }
   | {
       task_type: TaskType.SettleMatch
-      base: Address
+      base: `0x${string}`
       is_sell: boolean
-      quote: Address
+      quote: `0x${string}`
       volume: bigint
     }
   | {
       task_type: TaskType.PayOfflineFee
+      mint: `0x${string}`
+      amount: bigint
+      is_protocol: boolean
     }
   | {
       task_type: TaskType.NewWallet

--- a/packages/core/src/types/wallet.ts
+++ b/packages/core/src/types/wallet.ts
@@ -1,4 +1,5 @@
-import type { Address, Hex } from 'viem'
+import type { Hex } from 'viem'
+import type { Order } from './order.js'
 
 export type Exchange = 'binance' | 'coinbase' | 'kraken' | 'okx'
 
@@ -11,18 +12,8 @@ export type NetworkOrder = {
   timestamp: bigint
 }
 
-export type Order = {
-  id: string
-  quote_mint: Address
-  base_mint: Address
-  side: 'Buy' | 'Sell'
-  type: string
-  worst_case_price: string
-  amount: bigint
-}
-
 export type Balance = {
-  mint: Address
+  mint: `0x${string}`
   amount: bigint
   relayer_fee_balance: bigint
   protocol_fee_balance: bigint
@@ -56,21 +47,4 @@ export type OldTask = {
   description: string
   state: string
   committed: boolean
-}
-
-// Order History
-export enum OrderState {
-  Created = 'Created',
-  Matching = 'Matching',
-  SettlingMatch = 'SettlingMatch',
-  Filled = 'Filled',
-  Cancelled = 'Cancelled',
-}
-
-export type OrderMetadata = {
-  id: string
-  state: OrderState
-  filled: bigint
-  created: bigint
-  data: Order
 }

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -45,6 +45,14 @@ export async function getRelayerRaw(url: string, headers = {}) {
       headers,
       transformResponse: (data) => {
         try {
+          if (url.includes('/order-history')) {
+            return JSON.parse(data, (key, value) => {
+              if (typeof value === 'number' && key !== 'price') {
+                return BigInt(value)
+              }
+              return value
+            })
+          }
           return parseBigJSON(data)
         } catch (_error) {
           return data

--- a/packages/react/src/hooks/useOrderBookWebSocket.ts
+++ b/packages/react/src/hooks/useOrderBookWebSocket.ts
@@ -30,15 +30,17 @@ export function useOrderBookWebSocket(
     {
       filter: () => false,
       onMessage: (event) => {
-        const messageData = parseBigJSON(event.data)
-        if (
-          messageData.topic === ORDER_BOOK_ROUTE &&
-          (messageData.event?.type === 'NewOrder' ||
-            messageData.event?.type === 'OrderStateChange') &&
-          messageData.event?.order
-        ) {
-          onUpdate?.(messageData.event.order)
-        }
+        try {
+          const messageData = parseBigJSON(event.data)
+          if (
+            messageData.topic === ORDER_BOOK_ROUTE &&
+            (messageData.event?.type === 'NewOrder' ||
+              messageData.event?.type === 'OrderStateChange') &&
+            messageData.event?.order
+          ) {
+            onUpdate?.(messageData.event.order)
+          }
+        } catch (_) {}
       },
       share: true,
       shouldReconnect: () => true,

--- a/packages/react/src/hooks/useTaskHistoryWebSocket.ts
+++ b/packages/react/src/hooks/useTaskHistoryWebSocket.ts
@@ -35,14 +35,16 @@ export function useTaskHistoryWebSocket(
     {
       filter: () => false,
       onMessage(event) {
-        const messageData = parseBigJSON(event.data)
-        if (
-          walletId &&
-          messageData.topic === WS_TASK_HISTORY_ROUTE(walletId) &&
-          messageData.event?.type === 'TaskHistoryUpdate' &&
-          messageData.event?.task
-        )
-          onUpdate?.(messageData.event.task)
+        try {
+          const messageData = parseBigJSON(event.data)
+          if (
+            walletId &&
+            messageData.topic === WS_TASK_HISTORY_ROUTE(walletId) &&
+            messageData.event?.type === 'TaskHistoryUpdate' &&
+            messageData.event?.task
+          )
+            onUpdate?.(messageData.event.task)
+        } catch (_) {}
       },
       share: true,
       shouldReconnect: () => true,

--- a/packages/react/src/hooks/useWalletWebSocket.ts
+++ b/packages/react/src/hooks/useWalletWebSocket.ts
@@ -33,14 +33,16 @@ export function useWalletWebsocket(parameters: UseWalletParameters = {}) {
     {
       filter: () => false,
       onMessage: (event) => {
-        const messageData = parseBigJSON(event.data)
-        if (
-          walletId &&
-          messageData.topic === WALLET_ROUTE(walletId) &&
-          messageData.event?.type === 'WalletUpdate' &&
-          messageData.event?.wallet
-        )
-          onUpdate?.(messageData.event.wallet)
+        try {
+          const messageData = parseBigJSON(event.data)
+          if (
+            walletId &&
+            messageData.topic === WALLET_ROUTE(walletId) &&
+            messageData.event?.type === 'WalletUpdate' &&
+            messageData.event?.wallet
+          )
+            onUpdate?.(messageData.event.wallet)
+        } catch (_) {}
       },
       share: true,
       shouldReconnect: () => true,


### PR DESCRIPTION
This PR downstreams API response type changes from the relayer that adds more data to the `OrderMetadata` type and `PayFeeTask` type. Also refactors order-related types into their own file for readability.