### PR TITLE
node: export core actions and constants

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,4 +1,7 @@
 export * from '@renegade-fi/core'
+export * from '@renegade-fi/core/actions'
+export * from '@renegade-fi/core/constants'
+
 import { createConfig as core_createConfig } from '@renegade-fi/core/'
 
 import * as RustUtils from '../renegade-utils/index.js'


### PR DESCRIPTION
This PR exports actions and constants from `core` to the `node` package.