### PR TITLE
node: fix index import

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/node
 
+## 0.0.42
+
+### Patch Changes
+
+- node: fix index import
+
 ## 0.0.41
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,7 +7,7 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "typecheck": "tsc --noEmit"
   },
-  "version": "0.0.41",
+  "version": "0.0.42",
   "files": [
     "dist/**",
     "!dist/**/*.tsbuildinfo",

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -2,7 +2,7 @@ export * from '@renegade-fi/core'
 export * from '@renegade-fi/core/actions'
 export * from '@renegade-fi/core/constants'
 
-import { createConfig as core_createConfig } from '@renegade-fi/core/'
+import { createConfig as core_createConfig } from '@renegade-fi/core'
 
 import * as RustUtils from '../renegade-utils/index.js'
 


### PR DESCRIPTION
This PR fixes a typo in the import in the `node` package.