### PR TITLE
core: add Arbitrum Sepolia chain

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.0.42
+
+### Patch Changes
+
+- core: Add Arbitrum Sepolia
+
 ## 0.0.41
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "scripts": {
     "build": "pnpm run clean && pnpm run build:esm+types",
     "build:esm+types": "tsc --project tsconfig.build.json --outDir ./dist/esm --declaration --declarationMap --declarationDir ./dist/types",

--- a/packages/core/src/utils/viem.ts
+++ b/packages/core/src/utils/viem.ts
@@ -1,19 +1,22 @@
 import { createPublicClient, defineChain, http } from 'viem'
-
-const isDevelopment =
-  process.env.RPC_URL?.includes('dev') ||
-  process.env.NEXT_PUBLIC_RPC_URL?.includes('dev')
+import { arbitrumSepolia } from 'viem/chains'
 
 const rpcURL = process.env.RPC_URL
   ? `https://${process.env.RPC_URL}`
   : process.env.NEXT_PUBLIC_RPC_URL
     ? `https://${process.env.NEXT_PUBLIC_RPC_URL}`
-    : `https://${isDevelopment ? 'dev' : ''}sequencer.renegade.fi`
+    : 'https://dev.sequencer.renegade.fi'
 
-export const chain = defineChain({
+const chainId = process.env.CHAIN_ID
+  ? process.env.CHAIN_ID
+  : process.env.NEXT_PUBLIC_CHAIN_ID
+    ? process.env.NEXT_PUBLIC_CHAIN_ID
+    : 473474
+
+const renegadeDevnet = defineChain({
   id: 473474,
-  name: isDevelopment ? 'Renegade Devnet' : 'Renegade Testnet',
-  network: isDevelopment ? 'Renegade Devnet' : 'Renegade Testnet',
+  name: 'Renegade Devnet',
+  network: 'Renegade Devnet',
   testnet: true,
   nativeCurrency: {
     decimals: 18,
@@ -26,6 +29,9 @@ export const chain = defineChain({
     },
   },
 })
+
+export const chain =
+  Number(chainId) === 421_614 ? arbitrumSepolia : renegadeDevnet
 
 export const viemClient = createPublicClient({
   chain,

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.0.44
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.0.42
+
 ## 0.0.43
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,7 +7,7 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "typecheck": "tsc --noEmit"
   },
-  "version": "0.0.43",
+  "version": "0.0.44",
   "files": [
     "dist/**",
     "!dist/**/*.tsbuildinfo",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/react
 
+## 0.0.43
+
+### Patch Changes
+
+- core: Add Arbitrum Sepolia
+- Updated dependencies
+  - @renegade-fi/core@0.0.42
+
 ## 0.0.42
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "scripts": {
     "build": "pnpm run clean && pnpm run build:esm+types",
     "build:esm+types": "tsc --project tsconfig.build.json --outDir ./dist --declaration --declarationMap --declarationDir ./dist/types",

--- a/packages/react/src/hydrate.ts
+++ b/packages/react/src/hydrate.ts
@@ -30,7 +30,7 @@ export function Hydrate(parameters: React.PropsWithChildren<HydrateProps>) {
     const initRustUtils = async () => {
       try {
         await config.utils.default()
-        config.setState(x => ({ ...x, initialized: true }))
+        config.setState((x) => ({ ...x, initialized: true }))
         console.log('🦀 Rust utils initialized successfully')
         // Hydration needs to wait for WASM to initialize, causing state flash
         if (!config._internal.ssr) return

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.0.42
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.0.42
+
 ## 0.0.41
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [


### PR DESCRIPTION
This PR adds the Arbitrum Sepolia chain to the SDK, to be used by setting the `CHAIN_ID` env variable.