### PR TITLE
core, react: export cookiestorage

### DIFF
--- a/packages/core/src/actions/reconnect.ts
+++ b/packages/core/src/actions/reconnect.ts
@@ -6,7 +6,6 @@ export async function reconnect(config: Config) {
   try {
     invariant(config.state.seed, 'No seed found')
     invariant(config.state.id, 'No id found')
-    invariant(config.state.status === 'in relayer', 'Not previously connected')
     const wallet = await getWalletFromRelayer(config)
     if (wallet) {
       console.log('🚝 Reconnecting on mount')

--- a/packages/core/src/createConfig.ts
+++ b/packages/core/src/createConfig.ts
@@ -62,7 +62,6 @@ export function createConfig(parameters: CreateConfigParameters): Config {
       seed: undefined,
       status: 'disconnected',
       id: undefined,
-      initialized: false,
     }
   }
 
@@ -89,6 +88,7 @@ export function createConfig(parameters: CreateConfigParameters): Config {
 
   return {
     utils: parameters.utils,
+    storage,
     relayerUrl,
     priceReporterUrl,
     darkPoolAddress: parameters.darkPoolAddress,
@@ -161,6 +161,7 @@ export function createConfig(parameters: CreateConfigParameters): Config {
 }
 
 export type Config = {
+  readonly storage: Storage | null
   darkPoolAddress: Address
   getPriceReporterBaseUrl: () => string
   getPriceReporterHTTPBaseUrl: (route?: string) => string

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -222,6 +222,12 @@ export * from '../types/task.js'
 
 export { formatAmount, parseAmount } from '../utils/format.js'
 
+export {
+  cookieStorage,
+  cookieToInitialState,
+  parseCookie,
+} from '../utils/cookie.js'
+
 export { deepEqual } from '../utils/deepEqual.js'
 
 export { postRelayerRaw } from '../utils/http.js'

--- a/packages/core/src/hydrate.ts
+++ b/packages/core/src/hydrate.ts
@@ -9,12 +9,10 @@ type HydrateParameters = {
 export function hydrate(config: Config, parameters: HydrateParameters) {
   const { initialState, reconnectOnMount } = parameters
 
-  // TODO: Handle initial state
   if (initialState && !config._internal.store.persist.hasHydrated())
     config.setState({
       ...initialState,
-      status: reconnectOnMount ? 'looking up' : 'disconnected',
-      seed: reconnectOnMount ? config.state.seed : undefined,
+      status: reconnectOnMount ? initialState.status : 'disconnected',
     })
 
   return {
@@ -22,8 +20,6 @@ export function hydrate(config: Config, parameters: HydrateParameters) {
       if (config._internal.ssr) {
         console.log('💧 SSR enabled, rehydrating state')
         await config._internal.store.persist.rehydrate()
-        // Must delay initialization until after rehydration
-        config.setState((x) => ({ ...x, initialized: true }))
       }
 
       if (reconnectOnMount) {

--- a/packages/core/src/utils/cookie.ts
+++ b/packages/core/src/utils/cookie.ts
@@ -1,0 +1,33 @@
+import type { Config, State } from '../createConfig.js'
+import type { BaseStorage } from '../createStorage.js'
+import { deserialize } from './deserialize.js'
+
+export const cookieStorage = {
+  getItem(key) {
+    if (typeof window === 'undefined') return null
+    const value = parseCookie(document.cookie, key)
+    return value ?? null
+  },
+  setItem(key, value) {
+    if (typeof window === 'undefined') return
+    document.cookie = `${key}=${value}`
+  },
+  removeItem(key) {
+    if (typeof window === 'undefined') return
+    document.cookie = `${key}=;max-age=-1`
+  },
+} satisfies BaseStorage
+
+export function cookieToInitialState(config: Config, cookie?: string | null) {
+  if (!cookie) return undefined
+  const key = `${config.storage?.key}.store`
+  const parsed = parseCookie(cookie, key)
+  if (!parsed) return undefined
+  return deserialize<{ state: State }>(parsed).state
+}
+
+export function parseCookie(cookie: string, key: string) {
+  const keyValue = cookie.split('; ').find((x) => x.startsWith(`${key}=`))
+  if (!keyValue) return undefined
+  return keyValue.substring(key.length + 1)
+}

--- a/packages/react/src/exports/index.ts
+++ b/packages/react/src/exports/index.ts
@@ -166,6 +166,10 @@ export {
   // Utils
   formatAmount,
   parseAmount,
+  cookieStorage,
+  cookieToInitialState,
+  deepEqual,
+  parseCookie,
   // Types
   OrderState,
   TaskType,

--- a/packages/react/src/hydrate.ts
+++ b/packages/react/src/hydrate.ts
@@ -35,7 +35,9 @@ export function Hydrate(parameters: React.PropsWithChildren<HydrateProps>) {
         if (!config._internal.ssr) {
           config.setState((x) => ({ ...x, initialized: true }))
         }
-        onMount()
+        onMount().then(() =>
+          config.setState((x) => ({ ...x, initialized: true })),
+        )
       } catch (error) {
         console.error('❌ Failed to initialize Rust utils', error)
       }


### PR DESCRIPTION
This PR exports the cookieStorage module for usage as a storage option when persisting state. Also makes changes to ensure hydrating from a cookie works, especially when using SSR.