### PR TITLE
packages: react: exports: export PartialOrderFill

### DIFF
--- a/packages/react/src/exports/index.ts
+++ b/packages/react/src/exports/index.ts
@@ -151,6 +151,7 @@ export type {
   NetworkOrder,
   Order,
   OrderMetadata,
+  PartialOrderFill,
   Task,
   TaskInfo,
   TaskState,


### PR DESCRIPTION
This PR exposes the `PartialOrderFill` type for consumption in the frontend