### PR TITLE
react: refactor useBalances useOrders useFees to return Map

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.0.44
+
+### Patch Changes
+
+- set viem as config option and export cookie storage module
+
 ## 0.0.43
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "scripts": {
     "build": "pnpm run clean && pnpm run build:esm+types",
     "build:esm+types": "tsc --project tsconfig.build.json --outDir ./dist/esm --declaration --declarationMap --declarationDir ./dist/types",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/node
 
+## 0.0.46
+
+### Patch Changes
+
+- set viem as config option and export cookie storage module
+- Updated dependencies
+  - @renegade-fi/core@0.0.44
+
 ## 0.0.45
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,7 +7,7 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "typecheck": "tsc --noEmit"
   },
-  "version": "0.0.45",
+  "version": "0.0.46",
   "files": [
     "dist/**",
     "!dist/**/*.tsbuildinfo",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/react
 
+## 0.0.45
+
+### Patch Changes
+
+- set viem as config option and export cookie storage module
+- Updated dependencies
+  - @renegade-fi/core@0.0.44
+
 ## 0.0.44
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "scripts": {
     "build": "pnpm run clean && pnpm run build:esm+types",
     "build:esm+types": "tsc --project tsconfig.build.json --outDir ./dist --declaration --declarationMap --declarationDir ./dist/types",

--- a/packages/react/src/hooks/useBalances.ts
+++ b/packages/react/src/hooks/useBalances.ts
@@ -8,18 +8,19 @@ export type UseBalancesParameters = {
   filter?: boolean
 }
 
-export type UseBalancesReturnType = Balance[]
+export type UseBalancesReturnType = Map<string, Balance>
 
 export function useBalances(
   parameters: UseBalancesParameters = {},
 ): UseBalancesReturnType {
   const { filter = true } = parameters
   const { data: wallet } = useWallet()
-  if (!wallet) return []
+  if (!wallet?.balances) return new Map()
+  let balances = wallet.balances
   if (filter) {
-    return wallet.balances.filter(
+    balances = balances.filter(
       (balance) => balance.mint !== '0x0' && balance.amount,
     )
   }
-  return wallet.balances
+  return new Map(balances.map((balance) => [balance.mint, balance]))
 }

--- a/packages/react/src/hooks/useFees.ts
+++ b/packages/react/src/hooks/useFees.ts
@@ -1,24 +1,27 @@
 'use client'
 
 import type { Balance, Config } from '@renegade-fi/core'
-import { useBalances } from './useBalances.js'
+import { useWallet } from './useWallet.js'
 
 export type UseFeesParameters = {
   config?: Config
   filter?: boolean
 }
 
-export type UseFeesReturnType = Balance[]
+export type UseFeesReturnType = Map<string, Balance>
 
 export function useFees(parameters: UseFeesParameters = {}): UseFeesReturnType {
   const { filter = true } = parameters
-  const balances = useBalances({ filter: false })
+  const { data: wallet } = useWallet()
 
+  if (!wallet?.balances) return new Map()
+
+  let balances = wallet.balances
   if (filter) {
-    return balances.filter(
+    balances = balances.filter(
       (balance) => balance.protocol_fee_balance || balance.relayer_fee_balance,
     )
   }
 
-  return balances
+  return new Map(balances.map((balance) => [balance.mint, balance]))
 }

--- a/packages/react/src/hooks/useOrders.ts
+++ b/packages/react/src/hooks/useOrders.ts
@@ -8,16 +8,17 @@ export type UseOrdersParameters = {
   filter?: boolean
 }
 
-export type UseOrdersReturnType = Order[]
+export type UseOrdersReturnType = Map<string, Order>
 
 export function useOrders(
   parameters: UseOrdersParameters = {},
 ): UseOrdersReturnType {
   const { filter = true } = parameters
   const { data: wallet } = useWallet()
-  if (!wallet) return []
+  if (!wallet?.orders) return new Map()
+  let orders = wallet.orders
   if (filter) {
-    return wallet.orders.filter((order) => order.amount > 0)
+    orders = orders.filter((order) => order.amount > 0)
   }
-  return wallet.orders
+  return new Map(orders.map((order) => [order.id, order]))
 }

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @renegade-fi/test
 
+## 0.0.44
+
+### Patch Changes
+
+- set viem as config option and export cookie storage module
+- Updated dependencies
+  - @renegade-fi/core@0.0.44
+
 ## 0.0.43
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [


### PR DESCRIPTION
This PR refactors `useBalances` `useOrders` `useFees` to return Map types instead of Array for easier indexing.