### PR TITLE
trade: refactor useBalances useOrders useFees to return Map

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/react
 
+## 0.0.46
+
+### Patch Changes
+
+- react: refactor useBalances useOrders useFees to return Map
+
 ## 0.0.45
 
 ### Patch Changes

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/react
 
+## 0.0.47
+
+### Patch Changes
+
+- react: use `0x{string}` as balance / fee map index type
+
 ## 0.0.46
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "scripts": {
     "build": "pnpm run clean && pnpm run build:esm+types",
     "build:esm+types": "tsc --project tsconfig.build.json --outDir ./dist --declaration --declarationMap --declarationDir ./dist/types",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "scripts": {
     "build": "pnpm run clean && pnpm run build:esm+types",
     "build:esm+types": "tsc --project tsconfig.build.json --outDir ./dist --declaration --declarationMap --declarationDir ./dist/types",

--- a/packages/react/src/hooks/useBalances.ts
+++ b/packages/react/src/hooks/useBalances.ts
@@ -8,18 +8,19 @@ export type UseBalancesParameters = {
   filter?: boolean
 }
 
-export type UseBalancesReturnType = Balance[]
+export type UseBalancesReturnType = Map<string, Balance>
 
 export function useBalances(
   parameters: UseBalancesParameters = {},
 ): UseBalancesReturnType {
   const { filter = true } = parameters
   const { data: wallet } = useWallet()
-  if (!wallet) return []
+  if (!wallet?.balances) return new Map()
+  let balances = wallet.balances
   if (filter) {
-    return wallet.balances.filter(
+    balances = balances.filter(
       (balance) => balance.mint !== '0x0' && balance.amount,
     )
   }
-  return wallet.balances
+  return new Map(balances.map((balance) => [balance.mint, balance]))
 }

--- a/packages/react/src/hooks/useBalances.ts
+++ b/packages/react/src/hooks/useBalances.ts
@@ -8,7 +8,7 @@ export type UseBalancesParameters = {
   filter?: boolean
 }
 
-export type UseBalancesReturnType = Map<string, Balance>
+export type UseBalancesReturnType = Map<`0x${string}`, Balance>
 
 export function useBalances(
   parameters: UseBalancesParameters = {},

--- a/packages/react/src/hooks/useFees.ts
+++ b/packages/react/src/hooks/useFees.ts
@@ -8,7 +8,7 @@ export type UseFeesParameters = {
   filter?: boolean
 }
 
-export type UseFeesReturnType = Map<string, Balance>
+export type UseFeesReturnType = Map<`0x${string}`, Balance>
 
 export function useFees(parameters: UseFeesParameters = {}): UseFeesReturnType {
   const { filter = true } = parameters

--- a/packages/react/src/hooks/useFees.ts
+++ b/packages/react/src/hooks/useFees.ts
@@ -1,24 +1,24 @@
 'use client'
 
 import type { Balance, Config } from '@renegade-fi/core'
-import { useBalances } from './useBalances.js'
+import { useWallet } from './useWallet.js'
 
 export type UseFeesParameters = {
   config?: Config
   filter?: boolean
 }
 
-export type UseFeesReturnType = Balance[]
+export type UseFeesReturnType = Map<string, Balance>
 
 export function useFees(parameters: UseFeesParameters = {}): UseFeesReturnType {
   const { filter = true } = parameters
-  const balances = useBalances({ filter: false })
-
+  const { data: wallet } = useWallet()
+  if (!wallet?.balances) return new Map()
+  let balances = wallet.balances
   if (filter) {
-    return balances.filter(
+    balances = balances.filter(
       (balance) => balance.protocol_fee_balance || balance.relayer_fee_balance,
     )
   }
-
-  return balances
+  return new Map(balances.map((balance) => [balance.mint, balance]))
 }

--- a/packages/react/src/hooks/useOrders.ts
+++ b/packages/react/src/hooks/useOrders.ts
@@ -8,16 +8,17 @@ export type UseOrdersParameters = {
   filter?: boolean
 }
 
-export type UseOrdersReturnType = Order[]
+export type UseOrdersReturnType = Map<string, Order>
 
 export function useOrders(
   parameters: UseOrdersParameters = {},
 ): UseOrdersReturnType {
   const { filter = true } = parameters
   const { data: wallet } = useWallet()
-  if (!wallet) return []
+  if (!wallet?.orders) return new Map()
+  let orders = wallet.orders
   if (filter) {
-    return wallet.orders.filter((order) => order.amount > 0)
+    orders = orders.filter((order) => order.amount > 0)
   }
-  return wallet.orders
+  return new Map(orders.map((order) => [order.id, order]))
 }


### PR DESCRIPTION
This PR refactors `useBalances` `useOrders` `useFees` to return Map types instead of Array for easier indexing.