### PR TITLE
core: actions: matching pool create/destroy

### DIFF
--- a/packages/core/src/actions/createMatchingPool.ts
+++ b/packages/core/src/actions/createMatchingPool.ts
@@ -1,0 +1,27 @@
+import { ADMIN_MATCHING_POOL_CREATE_ROUTE } from '../constants.js'
+import type { Config } from '../createConfig.js'
+import { postRelayerWithAdmin } from '../utils/http.js'
+
+export type CreateMatchingPoolParameters = {
+  matchingPool: string
+}
+
+export async function createMatchingPool(
+  config: Config,
+  parameters: CreateMatchingPoolParameters,
+) {
+  const { matchingPool } = parameters
+  const { getRelayerBaseUrl } = config
+
+  try {
+    await postRelayerWithAdmin(
+      config,
+      getRelayerBaseUrl(ADMIN_MATCHING_POOL_CREATE_ROUTE(matchingPool)),
+    )
+  } catch (error) {
+    console.error(`Failed to create matching pool ${matchingPool}`, {
+      error,
+    })
+    throw error
+  }
+}

--- a/packages/core/src/actions/destroyMatchingPool.ts
+++ b/packages/core/src/actions/destroyMatchingPool.ts
@@ -1,0 +1,27 @@
+import { ADMIN_MATCHING_POOL_DESTROY_ROUTE } from '../constants.js'
+import type { Config } from '../createConfig.js'
+import { postRelayerWithAdmin } from '../utils/http.js'
+
+export type DestroyMatchingPoolParameters = {
+  matchingPool: string
+}
+
+export async function destroyMatchingPool(
+  config: Config,
+  parameters: DestroyMatchingPoolParameters,
+) {
+  const { matchingPool } = parameters
+  const { getRelayerBaseUrl } = config
+
+  try {
+    await postRelayerWithAdmin(
+      config,
+      getRelayerBaseUrl(ADMIN_MATCHING_POOL_DESTROY_ROUTE(matchingPool)),
+    )
+  } catch (error) {
+    console.error(`Failed to destroy matching pool ${matchingPool}`, {
+      error,
+    })
+    throw error
+  }
+}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -150,7 +150,14 @@ export const WS_WALLET_ORDERS_ROUTE = (wallet_id: string) =>
 // Admin
 ////////////////////////////////////////////////////////////////////////////////
 
+// Fetches all open orders
 export const ADMIN_OPEN_ORDERS_ROUTE = '/admin/open-orders'
+// Creates a matching pool
+export const ADMIN_MATCHING_POOL_CREATE_ROUTE = (matching_pool: string) =>
+  `/admin/matching_pools/${matching_pool}`
+// Destroys a matching pool
+export const ADMIN_MATCHING_POOL_DESTROY_ROUTE = (matching_pool: string) =>
+  `/admin/matching_pools/${matching_pool}/destroy`
 
 ////////////////////////////////////////////////////////////////////////////////
 // Price Reporter

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -8,10 +8,12 @@ export {
   cancelOrder,
 } from '../actions/cancelOrder.js'
 
+export { type ConnectReturnType, connect } from '../actions/connect.js'
+
 export {
-  type ConnectReturnType,
-  connect,
-} from '../actions/connect.js'
+  type CreateMatchingPoolParameters,
+  createMatchingPool,
+} from '../actions/createMatchingPool.js'
 
 export {
   type CreateOrderParameters,
@@ -31,9 +33,11 @@ export {
 } from '../actions/deposit.js'
 
 export {
-  type DisconnectReturnType,
-  disconnect,
-} from '../actions/disconnect.js'
+  type DestroyMatchingPoolParameters,
+  destroyMatchingPool,
+} from '../actions/destroyMatchingPool.js'
+
+export { type DisconnectReturnType, disconnect } from '../actions/disconnect.js'
 
 export {
   type GetAuthorizationHeadersParameters,
@@ -70,10 +74,7 @@ export {
   getOrderHistory,
 } from '../actions/getOrderHistory.js'
 
-export {
-  type GetOrdersReturnType,
-  getOrders,
-} from '../actions/getOrders.js'
+export { type GetOrdersReturnType, getOrders } from '../actions/getOrders.js'
 
 export {
   type GetPkRootReturnType,
@@ -94,10 +95,7 @@ export {
   getPriceFromPriceReporter,
 } from '../actions/getPriceFromPriceReporter.js'
 
-export {
-  type GetSkRootReturnType,
-  getSkRoot,
-} from '../actions/getSkRoot.js'
+export { type GetSkRootReturnType, getSkRoot } from '../actions/getSkRoot.js'
 
 export {
   type GetTaskHistoryErrorType,

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -104,6 +104,29 @@ export async function postRelayerWithAuth(
   return await postRelayerRaw(url, body, headers)
 }
 
+export async function postRelayerWithAdmin(
+  config: Config,
+  url: string,
+  body?: string,
+) {
+  const { adminKey } = config
+  invariant(adminKey, 'Admin key is required')
+
+  const [auth, expiration] = config.utils.build_admin_headers(
+    adminKey,
+    body ?? '',
+    BigInt(Date.now()),
+  )
+
+  const headers = {
+    [RENEGADE_AUTH_HMAC_HEADER_NAME]: auth,
+    [RENEGADE_SIG_EXPIRATION_HEADER_NAME]: expiration,
+    'Content-Type': 'application/json',
+  }
+
+  return await postRelayerRaw(url, body, headers)
+}
+
 export async function getRelayerWithAuth(config: Config, url: string) {
   const skRoot = await getSkRoot(config)
   const [auth, expiration] = config.utils.build_auth_headers(


### PR DESCRIPTION
This PR adds 2 actions for the creation & destruction of matching pools via a relayer's admin API. This will be tested via consumption in the internal dashboard app