### PR TITLE
packages: core, react: get order metadata action / hook

### DIFF
--- a/packages/core/src/actions/getOrderMetadata.ts
+++ b/packages/core/src/actions/getOrderMetadata.ts
@@ -1,0 +1,29 @@
+import type { Config } from '../createConfig.js'
+import type { OrderMetadata } from '../types/order.js'
+import { ADMIN_ORDER_METADATA_ROUTE } from '../constants.js'
+import { getRelayerWithAdmin } from '../utils/http.js'
+import { BaseError, type BaseErrorType } from '../errors/base.js'
+
+export type GetOrderMetadataParameters = { id: string }
+
+export type GetOrderMetadataReturnType = OrderMetadata
+
+export type GetOrderMetadataErrorType = BaseErrorType
+
+export async function getOrderMetadata(
+  config: Config,
+  parameters: GetOrderMetadataParameters,
+): Promise<GetOrderMetadataReturnType> {
+  const { id } = parameters
+  const { getRelayerBaseUrl } = config
+
+  const res = await getRelayerWithAdmin(
+    config,
+    getRelayerBaseUrl(ADMIN_ORDER_METADATA_ROUTE(id)),
+  )
+
+  if (!res.orders) {
+    throw new BaseError('No orders found')
+  }
+  return res.order
+}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -152,6 +152,9 @@ export const WS_WALLET_ORDERS_ROUTE = (wallet_id: string) =>
 
 // Fetches all open orders
 export const ADMIN_OPEN_ORDERS_ROUTE = '/admin/open-orders'
+// Get the order metadata for a given order
+export const ADMIN_ORDER_METADATA_ROUTE = (order_id: string) =>
+  `/admin/orders/${order_id}/metadata`
 // Creates a matching pool
 export const ADMIN_MATCHING_POOL_CREATE_ROUTE = (matching_pool: string) =>
   `/admin/matching_pools/${matching_pool}`
@@ -165,7 +168,7 @@ export const ADMIN_CREATE_ORDER_IN_MATCHING_POOL_ROUTE = (wallet_id: string) =>
 export const ADMIN_ASSIGN_ORDER_ROUTE = (
   order_id: string,
   matching_pool: string,
-) => `/v0/admin/orders/${order_id}/assign-pool/${matching_pool}`
+) => `/admin/orders/${order_id}/assign-pool/${matching_pool}`
 
 ////////////////////////////////////////////////////////////////////////////////
 // Price Reporter

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -73,6 +73,12 @@ export {
 } from '../actions/getNetworkOrders.js'
 
 export {
+  type GetOpenOrdersReturnType,
+  type GetOpenOrdersErrorType,
+  getOpenOrders,
+} from '../actions/getOpenOrders.js'
+
+export {
   type GetOrderParameters,
   type GetOrderReturnType,
   getOrder,
@@ -83,6 +89,13 @@ export {
   type GetOrderHistoryReturnType,
   getOrderHistory,
 } from '../actions/getOrderHistory.js'
+
+export {
+  type GetOrderMetadataParameters,
+  type GetOrderMetadataReturnType,
+  type GetOrderMetadataErrorType,
+  getOrderMetadata,
+} from '../actions/getOrderMetadata.js'
 
 export { type GetOrdersReturnType, getOrders } from '../actions/getOrders.js'
 
@@ -177,9 +190,3 @@ export {
   type WithdrawReturnType,
   withdraw,
 } from '../actions/withdraw.js'
-
-export {
-  type GetOpenOrdersReturnType,
-  type GetOpenOrdersErrorType,
-  getOpenOrders,
-} from '../actions/getOpenOrders.js'

--- a/packages/core/src/exports/query.ts
+++ b/packages/core/src/exports/query.ts
@@ -21,6 +21,15 @@ export {
 } from '../query/getOrderHistory.js'
 
 export {
+  type GetOrderMetadataData,
+  type GetOrderMetadataOptions,
+  type GetOrderMetadataQueryFnData,
+  type GetOrderMetadataQueryKey,
+  getOrderMetadataQueryKey,
+  getOrderMetadataQueryOptions,
+} from '../query/getOrderMetadata.js'
+
+export {
   type GetPingData,
   type GetPingOptions,
   type GetPingQueryFnData,

--- a/packages/core/src/query/getOrderMetadata.ts
+++ b/packages/core/src/query/getOrderMetadata.ts
@@ -1,0 +1,48 @@
+import type { QueryOptions } from '@tanstack/query-core'
+import {
+  getOrderMetadata,
+  type GetOrderMetadataErrorType,
+  type GetOrderMetadataReturnType,
+  type GetOrderMetadataParameters,
+} from '../actions/getOrderMetadata.js'
+import type { Config } from '../createConfig.js'
+import type { Evaluate } from '../types/utils.js'
+import { filterQueryOptions, type ScopeKeyParameter } from './utils.js'
+
+export type GetOrderMetadataOptions = Evaluate<
+  GetOrderMetadataParameters & ScopeKeyParameter
+>
+
+export function getOrderMetadataQueryOptions(
+  config: Config,
+  options: GetOrderMetadataOptions,
+) {
+  return {
+    async queryFn({ queryKey }) {
+      const { scopeKey: _, ...parameters } = queryKey[1]
+      const orderMetadata = await getOrderMetadata(config, parameters)
+      return orderMetadata ?? null
+    },
+    queryKey: getOrderMetadataQueryKey({
+      scopeKey: config.state.id,
+      ...options,
+    }),
+  } as const satisfies QueryOptions<
+    GetOrderMetadataQueryFnData,
+    GetOrderMetadataErrorType,
+    GetOrderMetadataData,
+    GetOrderMetadataQueryKey
+  >
+}
+
+export type GetOrderMetadataQueryFnData = Evaluate<GetOrderMetadataReturnType>
+
+export type GetOrderMetadataData = GetOrderMetadataQueryFnData
+
+export function getOrderMetadataQueryKey(options: GetOrderMetadataOptions) {
+  return ['order-metadata', filterQueryOptions(options)] as const
+}
+
+export type GetOrderMetadataQueryKey = ReturnType<
+  typeof getOrderMetadataQueryKey
+>

--- a/packages/react/src/exports/index.ts
+++ b/packages/react/src/exports/index.ts
@@ -103,6 +103,12 @@ export {
 } from '../hooks/useOrders.js'
 
 export {
+  useOrderMetadata,
+  type UseOrderMetadataParameters,
+  type UseOrderMetadataReturnType,
+} from '../hooks/useOrderMetadata.js'
+
+export {
   usePing,
   type UsePingParameters,
   type UsePingReturnType,

--- a/packages/react/src/hooks/useOrderMetadata.ts
+++ b/packages/react/src/hooks/useOrderMetadata.ts
@@ -1,0 +1,46 @@
+import {
+  getOrderMetadataQueryOptions,
+  type GetOrderMetadataData,
+  type GetOrderMetadataOptions,
+  type GetOrderMetadataQueryFnData,
+  type GetOrderMetadataQueryKey,
+} from '@renegade-fi/core/query'
+import type { ConfigParameter, QueryParameter } from '../types/properties.js'
+import type { Evaluate } from '@renegade-fi/core'
+import type { GetOrderMetadataErrorType } from '@renegade-fi/core/actions'
+import { useQuery, type UseQueryReturnType } from '../utils/query.js'
+import { useConfig } from './useConfig.js'
+
+export type UseOrderMetadataParameters<selectData = GetOrderMetadataData> =
+  Evaluate<
+    GetOrderMetadataOptions &
+      ConfigParameter &
+      QueryParameter<
+        GetOrderMetadataQueryFnData,
+        GetOrderMetadataErrorType,
+        selectData,
+        GetOrderMetadataQueryKey
+      >
+  >
+
+export type UseOrderMetadataReturnType<selectData = GetOrderMetadataData> =
+  UseQueryReturnType<selectData, GetOrderMetadataErrorType>
+
+export function useOrderMetadata<selectData = GetOrderMetadataData>(
+  parameters: UseOrderMetadataParameters<selectData>,
+): UseOrderMetadataReturnType<selectData> {
+  const { query } = parameters
+
+  const config = useConfig(parameters)
+
+  const options = getOrderMetadataQueryOptions(config, {
+    ...parameters,
+  })
+  const enabled = Boolean(query?.enabled ?? true)
+
+  return useQuery({
+    ...query,
+    ...options,
+    enabled,
+  })
+}


### PR DESCRIPTION
This PR introduces a core action + React hook for getting a given order's metadata via the admin API of a relayer to which one has admin access. This will be tested via consumption in the internal dashboard app.