### PR TITLE
core: utils: http: parse prices from admin order metadata field correctly

### DIFF
--- a/packages/core/src/actions/getOrderMetadata.ts
+++ b/packages/core/src/actions/getOrderMetadata.ts
@@ -22,8 +22,8 @@ export async function getOrderMetadata(
     getRelayerBaseUrl(ADMIN_ORDER_METADATA_ROUTE(id)),
   )
 
-  if (!res.orders) {
-    throw new BaseError('No orders found')
+  if (!res.order) {
+    throw new BaseError('No order found')
   }
   return res.order
 }

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -47,7 +47,11 @@ export async function getRelayerRaw(url: string, headers = {}) {
       headers,
       transformResponse: (data) => {
         try {
-          if (url.includes('/order-history') || url.includes('/open-orders')) {
+          if (
+            url.includes('/order-history') ||
+            url.includes('/open-orders') ||
+            url.includes('/metadata')
+          ) {
             return JSON.parse(data, (key, value) => {
               if (typeof value === 'number' && key !== 'price') {
                 return BigInt(value)


### PR DESCRIPTION
This PR adjusts the `getRelayerRaw` helper to properly parse prices from the `/admin/orders/:id/metadata` endpoint. This is done a bit fuzzily at the moment by checking if the URL simply includes the `/metadata` path fragment, but this is okay b/c 1) this is currently the only endpoint with that fragment, and 2) we are planning on changing this helper soon anyway to do custom parsing