### PR TITLE
core: allow client to get logs and force create wallet in connect

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @renegade-fi/core
 
+## 0.0.46
+
+### Patch Changes
+
+- core: allow client to get logs and force create wallet in connect
+
 ## 0.0.45
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/core",
   "description": "VanillaJS library for Renegade",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "scripts": {
     "build": "pnpm run clean && pnpm run build:esm+types",
     "build:esm+types": "tsc --project tsconfig.build.json --outDir ./dist/esm --declaration --declarationMap --declarationDir ./dist/types",

--- a/packages/core/src/actions/connect.ts
+++ b/packages/core/src/actions/connect.ts
@@ -4,13 +4,21 @@ import { getWalletFromRelayer } from './getWalletFromRelayer.js'
 import { getWalletId } from './getWalletId.js'
 import { checkForWalletUpdatesOnChain, lookupWallet } from './lookupWallet.js'
 
+export type ConnectParameters = {
+  isCreateWallet?: boolean
+}
+
 export type ConnectReturnType = {
   isLookup: boolean
   job: Promise<void>
 } | void
 
-export async function connect(config: Config): Promise<ConnectReturnType> {
+export async function connect(
+  config: Config,
+  params: ConnectParameters = {},
+): Promise<ConnectReturnType> {
   try {
+    const { isCreateWallet = false } = params
     const walletId = getWalletId(config)
     config.setState((x) => ({ ...x, id: walletId }))
 
@@ -35,7 +43,7 @@ export async function connect(config: Config): Promise<ConnectReturnType> {
 
     // Create wallet iff no WalletUpdated events found onchain
     const shouldCreateWallet = await checkForWalletUpdatesOnChain(config)
-    if (shouldCreateWallet) {
+    if (shouldCreateWallet || isCreateWallet) {
       return Promise.resolve({
         isLookup: false,
         job: createWallet(config),

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -9,6 +9,7 @@ export {
 } from '../actions/cancelOrder.js'
 
 export {
+  type ConnectParameters,
   type ConnectReturnType,
   connect,
 } from '../actions/connect.js'

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/node
 
+## 0.0.48
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.0.46
+
 ## 0.0.47
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,7 +7,7 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "typecheck": "tsc --noEmit"
   },
-  "version": "0.0.47",
+  "version": "0.0.48",
   "files": [
     "dist/**",
     "!dist/**/*.tsbuildinfo",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/react
 
+## 0.0.49
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.0.46
+
 ## 0.0.48
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@renegade-fi/react",
   "description": "React library for Renegade",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "scripts": {
     "build": "pnpm run clean && pnpm run build:esm+types",
     "build:esm+types": "tsc --project tsconfig.build.json --outDir ./dist --declaration --declarationMap --declarationDir ./dist/types",

--- a/packages/test/CHANGELOG.md
+++ b/packages/test/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @renegade-fi/test
 
+## 0.0.46
+
+### Patch Changes
+
+- Updated dependencies
+  - @renegade-fi/core@0.0.46
+
 ## 0.0.45
 
 ### Patch Changes

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@renegade-fi/test",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "description": "Testing helpers for Renegade",
   "private": true,
   "files": [


### PR DESCRIPTION
This PR allows for the library consumer to pass a flag to `connect` that will force a create wallet task to be executed. This is used to offload fetching of logs to the consumer.