### PR TITLE
core: actions: getOpenOrders: add pool query param

### DIFF
--- a/packages/core/src/actions/getOpenOrders.ts
+++ b/packages/core/src/actions/getOpenOrders.ts
@@ -1,25 +1,34 @@
 import type { Config } from '../createConfig.js'
-import type { OrderMetadata } from '../types/order.js'
+import type { OpenOrder } from '../types/order.js'
 import { ADMIN_OPEN_ORDERS_ROUTE } from '../constants.js'
 import { getRelayerWithAdmin } from '../utils/http.js'
 import { BaseError, type BaseErrorType } from '../errors/base.js'
 
-export type GetOpenOrdersReturnType = Map<string, OrderMetadata>
+export type GetOpenOrdersParams = {
+  matchingPool?: string
+}
+
+export type GetOpenOrdersReturnType = Map<string, OpenOrder>
 
 export type GetOpenOrdersErrorType = BaseErrorType
 
 export async function getOpenOrders(
   config: Config,
+  parameters: GetOpenOrdersParams = {},
 ): Promise<GetOpenOrdersReturnType> {
   const { getRelayerBaseUrl } = config
 
-  const res = await getRelayerWithAdmin(
-    config,
-    getRelayerBaseUrl(ADMIN_OPEN_ORDERS_ROUTE),
-  )
+  let url = getRelayerBaseUrl(ADMIN_OPEN_ORDERS_ROUTE)
+  if (parameters.matchingPool) {
+    const temp = new URL(url)
+    temp.searchParams.set('matching_pool', parameters.matchingPool)
+    url = temp.toString()
+  }
+
+  const res = await getRelayerWithAdmin(config, url)
 
   if (!res.orders) {
     throw new BaseError('No orders found')
   }
-  return new Map(res.orders.map((order: OrderMetadata) => [order.id, order]))
+  return new Map(res.orders.map((order: OpenOrder) => [order.order.id, order]))
 }

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -73,6 +73,7 @@ export {
 } from '../actions/getNetworkOrders.js'
 
 export {
+  type GetOpenOrdersParams,
   type GetOpenOrdersReturnType,
   type GetOpenOrdersErrorType,
   getOpenOrders,

--- a/packages/core/src/query/getOpenOrders.ts
+++ b/packages/core/src/query/getOpenOrders.ts
@@ -3,12 +3,15 @@ import {
   getOpenOrders,
   type GetOpenOrdersErrorType,
   type GetOpenOrdersReturnType,
+  type GetOpenOrdersParams,
 } from '../actions/getOpenOrders.js'
 import type { Config } from '../createConfig.js'
 import type { Evaluate } from '../types/utils.js'
 import { filterQueryOptions, type ScopeKeyParameter } from './utils.js'
 
-export type GetOpenOrdersOptions = Evaluate<ScopeKeyParameter>
+export type GetOpenOrdersOptions = Evaluate<
+  GetOpenOrdersParams & ScopeKeyParameter
+>
 
 export function getOpenOrdersQueryOptions(
   config: Config,
@@ -16,8 +19,8 @@ export function getOpenOrdersQueryOptions(
 ) {
   return {
     async queryFn({ queryKey }) {
-      const { scopeKey: _ } = queryKey[1]
-      const orders = await getOpenOrders(config)
+      const { scopeKey: _, ...parameters } = queryKey[1]
+      const orders = await getOpenOrders(config, parameters)
       return orders ?? null
     },
     queryKey: getOpenOrdersQueryKey(options),

--- a/packages/core/src/types/order.ts
+++ b/packages/core/src/types/order.ts
@@ -32,3 +32,8 @@ export type PartialOrderFill = {
   // The time at which the fill executed, in milliseconds since the epoch
   timestamp: bigint
 }
+
+export type OpenOrder = {
+  order: OrderMetadata
+  fillable: bigint
+}


### PR DESCRIPTION
This PR updates the `getOpenOrders` action to support an optional `?matching_pool` query param & expect a different response shape in accordance w/ https://github.com/renegade-fi/renegade/pull/711. This will be tested in downstream consumption of the SDK.