### PR TITLE
core: types: order: add price field to openorder

### DIFF
--- a/packages/core/src/types/order.ts
+++ b/packages/core/src/types/order.ts
@@ -35,5 +35,6 @@ export type PartialOrderFill = {
 
 export type OpenOrder = {
   order: OrderMetadata
-  fillable: bigint
+  fillable?: bigint
+  price?: number
 }


### PR DESCRIPTION
This PR updates the `OpenOrder` API type to include the `price` field (used to calculate the fillable amount) in accordance w/ https://github.com/renegade-fi/renegade/pull/711.

The fetch helper in `http.ts` already conditionally parses fields titled `price` as numbers for the `/open-orders` endpoint, so this field should be parsed appropriately.