### PR TITLE
core: actions: getOpenOrders: add include_fillable param

### DIFF
--- a/packages/core/src/actions/getOpenOrders.ts
+++ b/packages/core/src/actions/getOpenOrders.ts
@@ -6,6 +6,7 @@ import { BaseError, type BaseErrorType } from '../errors/base.js'
 
 export type GetOpenOrdersParams = {
   matchingPool?: string
+  includeFillable?: boolean
 }
 
 export type GetOpenOrdersReturnType = Map<string, OpenOrder>
@@ -18,14 +19,17 @@ export async function getOpenOrders(
 ): Promise<GetOpenOrdersReturnType> {
   const { getRelayerBaseUrl } = config
 
-  let url = getRelayerBaseUrl(ADMIN_OPEN_ORDERS_ROUTE)
+  const url = new URL(getRelayerBaseUrl(ADMIN_OPEN_ORDERS_ROUTE))
+
   if (parameters.matchingPool) {
-    const temp = new URL(url)
-    temp.searchParams.set('matching_pool', parameters.matchingPool)
-    url = temp.toString()
+    url.searchParams.set('matching_pool', parameters.matchingPool)
   }
 
-  const res = await getRelayerWithAdmin(config, url)
+  if (parameters.includeFillable) {
+    url.searchParams.set('include_fillable', String(true))
+  }
+
+  const res = await getRelayerWithAdmin(config, url.toString())
 
   if (!res.orders) {
     throw new BaseError('No orders found')


### PR DESCRIPTION
This PR exposes the `include_fillable` query parameter on the `/admin/open-orders` endpoint, which instructs the relayer to compute the total fillable amount for each open order. The logic for this is already present relayer-side, we just never included it in the action.