### PR TITLE
core: websocket waiter primitive

### DIFF
--- a/packages/core/src/actions/waitForTaskCompletion.ts
+++ b/packages/core/src/actions/waitForTaskCompletion.ts
@@ -4,7 +4,7 @@ import { getTaskStatus } from './getTaskStatus.js'
 import type { Config } from '../createConfig.js'
 import type { OldTask as Task } from '../types/wallet.js'
 
-export type WaitForTaskCompletionParameters = { id: string }
+export type WaitForTaskCompletionParameters = { id: string, timeout?: number }
 
 export type WaitForTaskCompletionReturnType = Promise<undefined>
 

--- a/packages/core/src/actions/waitForTaskCompletionWs.ts
+++ b/packages/core/src/actions/waitForTaskCompletionWs.ts
@@ -1,10 +1,9 @@
-import axios from 'axios'
 import type { Config } from '../createConfig.js'
-import { getTaskStatus } from './getTaskStatus.js'
 import type { WaitForTaskCompletionParameters } from './waitForTaskCompletion.js'
 import type { RelayerWebsocketMessage } from '../types/ws.js'
 import { TASK_STATUS_ROUTE } from '../constants.js'
 import { websocketWaiter } from '../utils/websocketWaiter.js'
+import { getTaskHistory } from './getTaskHistory.js'
 
 export async function waitForTaskCompletionWs(
   config: Config,
@@ -12,19 +11,18 @@ export async function waitForTaskCompletionWs(
 ): Promise<null | undefined> {
   const { id, timeout } = parameters
 
-  const url = config.getWebsocketBaseUrl()
   const topic = TASK_STATUS_ROUTE(id)
 
   const prefetch = async () => {
-    try {
-      await getTaskStatus(config, { id })
-    } catch (error) {
-      if (axios.isAxiosError(error)) {
-        if (error.response?.status === 404) {
-          // Assume a 404 means the task is completed
-          return null
-        }
-      }
+    const taskHistory = await getTaskHistory(config)
+    const task = taskHistory.get(id)
+
+    if (task?.state === 'Completed') {
+      return null
+    }
+
+    if (task?.state === 'Failed') {
+      throw new Error(`Task ${id} failed`)
     }
 
     return undefined
@@ -44,5 +42,5 @@ export async function waitForTaskCompletionWs(
     return undefined
   }
 
-  return websocketWaiter(config, url, topic, messageHandler, prefetch, timeout)
+  return websocketWaiter(config, topic, messageHandler, prefetch, timeout)
 }

--- a/packages/core/src/actions/waitForTaskCompletionWs.ts
+++ b/packages/core/src/actions/waitForTaskCompletionWs.ts
@@ -1,0 +1,48 @@
+import axios from 'axios'
+import type { Config } from '../createConfig.js'
+import { getTaskStatus } from './getTaskStatus.js'
+import type { WaitForTaskCompletionParameters } from './waitForTaskCompletion.js'
+import type { RelayerWebsocketMessage } from '../types/ws.js'
+import { TASK_STATUS_ROUTE } from '../constants.js'
+import { websocketWaiter } from '../utils/websocketWaiter.js'
+
+export async function waitForTaskCompletionWs(
+  config: Config,
+  parameters: WaitForTaskCompletionParameters,
+): Promise<null | undefined> {
+  const { id, timeout } = parameters
+
+  const url = config.getWebsocketBaseUrl()
+  const topic = TASK_STATUS_ROUTE(id)
+
+  const prefetch = async () => {
+    try {
+      await getTaskStatus(config, { id })
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        if (error.response?.status === 404) {
+          // Assume a 404 means the task is completed
+          return null
+        }
+      }
+    }
+
+    return undefined
+  }
+
+  const messageHandler = (message: RelayerWebsocketMessage) => {
+    if (message.topic === topic && message.event.type === 'TaskStatusUpdate') {
+      if (message.event.status?.state === 'Completed') {
+        return null
+      }
+
+      if (message.event.status?.state === 'Failed') {
+        throw new Error(`Task ${id} failed`)
+      }
+    }
+
+    return undefined
+  }
+
+  return websocketWaiter(config, url, topic, messageHandler, prefetch, timeout)
+}

--- a/packages/core/src/exports/actions.ts
+++ b/packages/core/src/exports/actions.ts
@@ -180,6 +180,8 @@ export {
   waitForTaskCompletion,
 } from '../actions/waitForTaskCompletion.js'
 
+export { waitForTaskCompletionWs } from '../actions/waitForTaskCompletionWs.js'
+
 export {
   type WatchStatusParameters,
   type WatchStatusReturnType,

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -167,6 +167,8 @@ export {
   waitForTaskCompletion,
 } from '../actions/waitForTaskCompletion.js'
 
+export { waitForTaskCompletionWs } from '../actions/waitForTaskCompletionWs.js'
+
 export {
   type WatchInitializedReturnType,
   watchInitialized,

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -48,7 +48,6 @@ export {
   depositRequest,
 } from '../actions/depositRequest.js'
 
-
 export {
   type DisconnectReturnType,
   disconnect,
@@ -147,7 +146,11 @@ export {
   lookupWallet,
 } from '../actions/lookupWallet.js'
 
-export { type PayFeesReturnType, type PayFeesErrorType, payFees } from '../actions/payFees.js'
+export {
+  type PayFeesReturnType,
+  type PayFeesErrorType,
+  payFees,
+} from '../actions/payFees.js'
 
 export {
   type SignMessageParameters,
@@ -242,6 +245,7 @@ export { Token } from '../types/token.js'
 export * from '../types/wallet.js'
 export * from '../types/order.js'
 export * from '../types/task.js'
+export * from '../types/ws.js'
 
 export {
   type Evaluate,
@@ -272,5 +276,7 @@ export { deepEqual } from '../utils/deepEqual.js'
 export { postRelayerRaw } from '../utils/http.js'
 
 export { WebSocketManager } from '../utils/websocket.js'
+
+export { websocketWaiter } from '../utils/websocketWaiter.js'
 
 export { parseBigJSON, stringifyForWasm } from '../utils/bigJSON.js'

--- a/packages/core/src/types/ws.ts
+++ b/packages/core/src/types/ws.ts
@@ -1,0 +1,4 @@
+export type RelayerWebsocketMessage = {
+  topic: string,
+  event: any
+}

--- a/packages/core/src/types/ws.ts
+++ b/packages/core/src/types/ws.ts
@@ -1,4 +1,4 @@
 export type RelayerWebsocketMessage = {
-  topic: string,
+  topic: string
   event: any
 }

--- a/packages/core/src/utils/websocketWaiter.ts
+++ b/packages/core/src/utils/websocketWaiter.ts
@@ -27,16 +27,15 @@ import type { RelayerWebsocketMessage } from '../types/ws.js'
  */
 export async function websocketWaiter<T>(
   config: Config,
-  url: string,
   topic: string,
   messageHandler: (message: RelayerWebsocketMessage) => T | undefined,
   prefetch?: () => Promise<T | undefined>,
   timeout?: number,
-): Promise<T | undefined> {
+): Promise<T> {
   return new Promise((resolve, reject) => {
     let promiseSettled = false
 
-    const ws = new WebSocket(url)
+    const ws = new WebSocket(config.getWebsocketBaseUrl())
     ws.onopen = () => {
       const message = buildSubscriptionMessage(config, topic)
       ws.send(JSON.stringify(message))

--- a/packages/core/src/utils/websocketWaiter.ts
+++ b/packages/core/src/utils/websocketWaiter.ts
@@ -1,0 +1,93 @@
+import { getSkRoot } from '../actions/getSkRoot.js'
+import {
+  RENEGADE_AUTH_HEADER_NAME,
+  RENEGADE_SIG_EXPIRATION_HEADER_NAME,
+} from '../constants.js'
+import type { Config } from '../createConfig.js'
+
+/**
+ * A lightweight method which resolves when a short-lived websocket connection is closed.
+ * The method will open the websocket connection, subscribe to the given topic
+ * (sending a subscription message in the format expected by the relayer),
+ * and close it when the message handler returns a value, resolving the promise with the value.
+ *
+ * If the timeout is reached, the promise will reject.
+ *
+ * Because this method is intended for short-lived websocket connections, it does not support reconnecting to the server.
+ * If the connection is closed, the method will throw an error.
+ */
+export async function websocketWaiter<T>(
+  config: Config,
+  url: string,
+  topic: string,
+  messageHandler: (message: any) => T | undefined,
+  timeout: number | undefined = undefined,
+): Promise<T | undefined> {
+  return new Promise((resolve, reject) => {
+    let promiseSettled = false
+
+    const ws = new WebSocket(url)
+    ws.onopen = () => {
+      const message = buildSubscriptionMessage(config, topic)
+      ws.send(JSON.stringify(message))
+    }
+
+    ws.onmessage = (event) => {
+      const message = JSON.parse(event.data)
+      try {
+        const result = messageHandler(message)
+        if (result) {
+          promiseSettled = true
+          resolve(result)
+          ws.close()
+        }
+      } catch (error) {
+        promiseSettled = true
+        reject(error)
+        ws.close()
+      }
+    }
+
+    ws.onclose = () => {
+      if (!promiseSettled) {
+        promiseSettled = true
+        reject(new Error('Websocket connection closed'))
+      }
+    }
+
+    ws.onerror = (error) => {
+      if (!promiseSettled) {
+        promiseSettled = true
+        reject(error)
+      }
+    }
+
+    setTimeout(() => {
+      if (!promiseSettled) {
+        promiseSettled = true
+        reject(new Error('Websocket connection timed out'))
+      }
+    }, timeout)
+  })
+}
+
+function buildSubscriptionMessage(config: Config, topic: string) {
+  const body = {
+    method: 'subscribe',
+    topic,
+  }
+  const skRoot = getSkRoot(config)
+  const [auth, expiration] = config.utils.build_auth_headers(
+    skRoot,
+    JSON.stringify(body),
+    BigInt(Date.now()),
+  )
+
+  return {
+    headers: {
+      [RENEGADE_AUTH_HEADER_NAME]: auth,
+      [RENEGADE_SIG_EXPIRATION_HEADER_NAME]: expiration,
+    },
+    body,
+  }
+}


### PR DESCRIPTION
This PR introduces a generic primitive for awaiting results on short-lived websocket connections, & uses it to create a websocket-based task completion waiter. This can be used to avoid polling-based waiters on the relayer, which may result in the client being rate-limited.

I tested this locally by using it in the bot server's `refresh-quoters` endpoint & asserting that the task completion waiter resolved when expected