### PR TITLE
core: utils: websocketWaiter: defer event parsing to consumer

### DIFF
--- a/packages/core/src/actions/waitForTaskCompletionWs.ts
+++ b/packages/core/src/actions/waitForTaskCompletionWs.ts
@@ -1,6 +1,5 @@
 import type { Config } from '../createConfig.js'
 import type { WaitForTaskCompletionParameters } from './waitForTaskCompletion.js'
-import type { RelayerWebsocketMessage } from '../types/ws.js'
 import { TASK_STATUS_ROUTE } from '../constants.js'
 import { websocketWaiter } from '../utils/websocketWaiter.js'
 import { getTaskHistory } from './getTaskHistory.js'
@@ -28,13 +27,14 @@ export async function waitForTaskCompletionWs(
     return undefined
   }
 
-  const messageHandler = (message: RelayerWebsocketMessage) => {
-    if (message.topic === topic && message.event.type === 'TaskStatusUpdate') {
-      if (message.event.status?.state === 'Completed') {
+  const messageHandler = (message: any) => {
+    const parsedMessage = JSON.parse(message)
+    if (parsedMessage.topic === topic && parsedMessage.event.type === 'TaskStatusUpdate') {
+      if (parsedMessage.event.status?.state === 'Completed') {
         return null
       }
 
-      if (message.event.status?.state === 'Failed') {
+      if (parsedMessage.event.status?.state === 'Failed') {
         throw new Error(`Task ${id} failed`)
       }
     }

--- a/packages/core/src/exports/index.ts
+++ b/packages/core/src/exports/index.ts
@@ -245,7 +245,6 @@ export { Token } from '../types/token.js'
 export * from '../types/wallet.js'
 export * from '../types/order.js'
 export * from '../types/task.js'
-export * from '../types/ws.js'
 
 export {
   type Evaluate,

--- a/packages/core/src/types/ws.ts
+++ b/packages/core/src/types/ws.ts
@@ -1,4 +1,0 @@
-export type RelayerWebsocketMessage = {
-  topic: string
-  event: any
-}


### PR DESCRIPTION
This PR defers the parsing of websocket messages in the `websocketWaiter` to the consumer, to give control over e.g. `bigint` parsing. This has been tested via downstream consumption in an internal package.