### PR TITLE
core: types: token: make findByAddress case-insensitive

### DIFF
--- a/packages/core/src/types/token.ts
+++ b/packages/core/src/types/token.ts
@@ -53,7 +53,7 @@ export class Token {
 
   static findByAddress(address: Address): Token {
     const tokenData = tokenMapping.tokens.find(
-      (token) => token.address === address,
+      (token) => token.address.toLowerCase() === address.toLowerCase(),
     )
     if (tokenData) {
       return new Token(


### PR DESCRIPTION
This PR makes the `Token.findByAddress` method case-insensitive, in case the token mapping uses checksum addresses (as is currently the case w/ the mainnet token mapping).