### PR TITLE
core: remove set state in getWallet fn

### DIFF
--- a/packages/core/src/actions/getWalletFromRelayer.ts
+++ b/packages/core/src/actions/getWalletFromRelayer.ts
@@ -28,10 +28,6 @@ export async function getWalletFromRelayer(
   if (!res.wallet) {
     throw new BaseError('Wallet not found')
   }
-  config.setState((x) => ({
-    ...x,
-    status: 'in relayer',
-  }))
   if (filterDefaults) {
     return {
       ...res.wallet,


### PR DESCRIPTION
This PR removes the `setState` function call in `getWalletFromRelayer` as it was causing issues in certain cases when a disconnect was called, but the relayer responded with the wallet object, resulting in an inconsistent `{ seed: undefined, status: "in relayer" } `state. It's a better separation of concerns for only functions directly related to connecting / disconnecting to modify these state variables anyways.